### PR TITLE
✨ Introduce `<Dialog />` component

### DIFF
--- a/addon/components/dialog.hbs
+++ b/addon/components/dialog.hbs
@@ -1,0 +1,43 @@
+{{#if @isOpen}}
+  {{#let (element this.tagName) as |Tag|}}
+    {{#in-element this.$portalRoot insertBefore=null}}
+      <Tag
+        id={{this.guid}}
+
+        role="dialog"
+        aria-modal="true"
+
+        {{focus-trap}}
+        {{click-outside @onClose}}
+        {{this.handleEscapeKey @isOpen @onClose}}
+        {{on "click" this.stopPropagation}}
+
+        ...attributes
+      >
+        {{yield (hash
+          isOpen=@isOpen
+          onClose=@onClose
+          Overlay=(
+            component "dialog/-overlay"
+            guid=this.overlayGuid
+            dialogGuid=this.guid
+            isOpen=@isOpen
+            onClose=@onClose
+          )
+          Title=(
+            component "dialog/-title"
+            guid=this.titleGuid
+            dialogGuid=this.guid
+            isOpen=@isOpen
+          )
+          Description=(
+            component "dialog/-description"
+            guid=this.descriptionGuid
+            dialogGuid=this.guid
+            isOpen=@isOpen
+          )
+        )}}
+      </Tag>
+    {{/in-element}}
+  {{/let}}
+{{/if}}

--- a/addon/components/dialog.js
+++ b/addon/components/dialog.js
@@ -1,0 +1,91 @@
+import Component from '@glimmer/component';
+import { typeOf } from '@ember/utils';
+import { guidFor } from '@ember/object/internals';
+
+import { modifier } from 'ember-modifier';
+
+import { Keys } from 'ember-headlessui/utils/keyboard';
+
+export default class DialogComponent extends Component {
+  DEFAULT_TAG_NAME = 'div';
+
+  guid = `${guidFor(this)}-headlessui-dialog`;
+  $portalRoot = document.body;
+
+  handleEscapeKey = modifier((_element, [isOpen, onClose]) => {
+    let handler = (event) => {
+      if (event.key !== Keys.Escape) return;
+      if (!isOpen) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      onClose();
+    };
+
+    window.addEventListener('keyup', handler);
+    return () => {
+      window.removeEventListener('keyup', handler);
+    };
+  });
+
+  constructor() {
+    super(...arguments);
+
+    let { isOpen, onClose } = this.args;
+
+    if (isOpen === undefined && onClose === undefined) {
+      throw new Error(
+        'You have to provide an `isOpen` and an `onClose` prop to the `Dialog` component.'
+      );
+    }
+
+    if (isOpen === undefined) {
+      throw new Error(
+        'You provided an `onClose` prop to the `Dialog`, but forgot an `isOpen` prop.'
+      );
+    }
+
+    if (onClose === undefined) {
+      throw new Error(
+        'You provided an `isOpen` prop to the `Dialog`, but forgot an `onClose` prop.'
+      );
+    }
+
+    if (typeOf(isOpen) !== 'boolean') {
+      throw new Error(
+        `You provided an \`isOpen\` prop to the \`Dialog\`, but the value is not a boolean. Received: ${isOpen}`
+      );
+    }
+
+    if (typeOf(onClose) !== 'function') {
+      throw new Error(
+        `You provided an \`onClose\` prop to the \`Dialog\`, but the value is not a function. Received: ${onClose}`
+      );
+    }
+  }
+
+  get tagName() {
+    return this.args.as || this.DEFAULT_TAG_NAME;
+  }
+
+  get overlayGuid() {
+    return `${this.guid}-overlay`;
+  }
+
+  get titleGuid() {
+    return `${this.guid}-title`;
+  }
+
+  get descriptionGuid() {
+    return `${this.guid}-description`;
+  }
+
+  get $element() {
+    return document.getElementById(this.guid);
+  }
+
+  stopPropagation(event) {
+    event.stopPropagation();
+  }
+}

--- a/addon/components/dialog/-description.hbs
+++ b/addon/components/dialog/-description.hbs
@@ -1,0 +1,5 @@
+{{#let (element this.tagName) as |Tag|}}
+  <Tag id={{@guid}} {{this.ariaDescribedby @dialogGuid}} ...attributes>
+    {{yield (hash isOpen=@isOpen)}}
+  </Tag>
+{{/let}}

--- a/addon/components/dialog/-description.js
+++ b/addon/components/dialog/-description.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+
+import { modifier } from 'ember-modifier';
+
+export default class DialogDescriptionComponent extends Component {
+  DEFAULT_TAG_NAME = 'p';
+
+  constructor() {
+    super(...arguments);
+
+    let { dialogGuid } = this.args;
+
+    if (dialogGuid === undefined) {
+      throw new Error(
+        '<Dialog::-Description /> is missing a parent <Dialog /> component.'
+      );
+    }
+  }
+
+  ariaDescribedby = modifier((element, [dialogGuid]) => {
+    let $dialog = document.getElementById(dialogGuid);
+    $dialog.setAttribute('aria-describedby', element.id);
+
+    return () => {
+      $dialog.removeAttribute('aria-describedby');
+    };
+  });
+
+  get tagName() {
+    return this.args.as || this.DEFAULT_TAG_NAME;
+  }
+}

--- a/addon/components/dialog/-overlay.hbs
+++ b/addon/components/dialog/-overlay.hbs
@@ -1,0 +1,5 @@
+{{#let (element this.tagName) as |Tag|}}
+  <Tag id={{@guid}} role="button" {{on "click" this.handleClick}} ...attributes>
+    {{yield (hash isOpen=@isOpen)}}
+  </Tag>
+{{/let}}

--- a/addon/components/dialog/-overlay.js
+++ b/addon/components/dialog/-overlay.js
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class DialogOverlayComponent extends Component {
+  DEFAULT_TAG_NAME = 'div';
+
+  constructor() {
+    super(...arguments);
+
+    let { dialogGuid } = this.args;
+
+    if (dialogGuid === undefined) {
+      throw new Error(
+        '<Dialog::-Overlay /> is missing a parent <Dialog /> component.'
+      );
+    }
+  }
+
+  get tagName() {
+    return this.args.as || this.DEFAULT_TAG_NAME;
+  }
+
+  @action
+  handleClick(event) {
+    let { onClose } = this.args;
+    event.preventDefault();
+    event.stopPropagation();
+
+    onClose();
+  }
+}

--- a/addon/components/dialog/-title.hbs
+++ b/addon/components/dialog/-title.hbs
@@ -1,0 +1,5 @@
+{{#let (element this.tagName) as |Tag|}}
+  <Tag id={{@guid}} {{this.ariaLabelledby @dialogGuid}} ...attributes>
+    {{yield (hash isOpen=@isOpen)}}
+  </Tag>
+{{/let}}

--- a/addon/components/dialog/-title.js
+++ b/addon/components/dialog/-title.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+
+import { modifier } from 'ember-modifier';
+
+export default class DialogTitleComponent extends Component {
+  DEFAULT_TAG_NAME = 'h2';
+
+  constructor() {
+    super(...arguments);
+
+    let { dialogGuid } = this.args;
+
+    if (dialogGuid === undefined) {
+      throw new Error(
+        '<Dialog::-Title /> is missing a parent <Dialog /> component.'
+      );
+    }
+  }
+
+  ariaLabelledby = modifier((element, [dialogGuid]) => {
+    let $dialog = document.getElementById(dialogGuid);
+    $dialog.setAttribute('aria-labelledby', element.id);
+
+    return () => {
+      $dialog.removeAttribute('aria-labelledby');
+    };
+  });
+
+  get tagName() {
+    return this.args.as || this.DEFAULT_TAG_NAME;
+  }
+}

--- a/app/components/dialog.js
+++ b/app/components/dialog.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/components/dialog';

--- a/app/components/dialog/-description.js
+++ b/app/components/dialog/-description.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/components/dialog/-description';

--- a/app/components/dialog/-overlay.js
+++ b/app/components/dialog/-overlay.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/components/dialog/-overlay';

--- a/app/components/dialog/-title.js
+++ b/app/components/dialog/-title.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/components/dialog/-title';

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,10 +8,10 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.24',
+        name: 'ember--3.25',
         npm: {
           devDependencies: {
-            'ember-source': '~3.24.3',
+            'ember-source': '~3.25.0',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-css-transitions": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
+    "ember-focus-trap": "^0.7.0",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-on-helper": "^0.1.0",

--- a/tests/accessibility-assertions.js
+++ b/tests/accessibility-assertions.js
@@ -1,0 +1,529 @@
+import Qunit from 'qunit';
+
+function getDialog() {
+  return document.querySelector('[role="dialog"]');
+}
+
+function getDialogOverlay() {
+  return document.querySelector('[id$="-headlessui-dialog-overlay"]');
+}
+
+function getDialogTitle() {
+  return document.querySelector('[id$="-headlessui-dialog-title"]');
+}
+
+function getDialogDescription() {
+  return document.querySelector('[id$="-headlessui-dialog-description"]');
+}
+
+const DialogState = {
+  /** The dialog is visible to the user. */
+  Visible: 'Visible',
+
+  /** The dialog is **not** visible to the user. It's still in the DOM, but it is hidden. */
+  InvisibleHidden: 'InvisibleHidden',
+
+  /** The dialog is **not** visible to the user. It's not in the DOM, it is unmounted. */
+  InvisibleUnmounted: 'InvisibleUnmounted',
+};
+
+function assertNever(x) {
+  throw new Error('Unexpected object: ' + x);
+}
+
+function assertActiveElement(element) {
+  try {
+    if (element === null) {
+      Qunit.assert.notEqual(element, null);
+      return;
+    }
+
+    Qunit.assert.equal(element, document.activeElement);
+  } catch (err) {
+    Error.captureStackTrace(err, assertActiveElement);
+    throw err;
+  }
+}
+
+function assertHidden(element) {
+  try {
+    if (element === null) {
+      Qunit.assert.notEqual(element, null);
+      return;
+    }
+
+    Qunit.assert.dom(element).hasAttribute('hidden');
+    Qunit.assert.dom(element).hasStyle({ display: 'none' });
+  } catch (err) {
+    Error.captureStackTrace(err, assertHidden);
+    throw err;
+  }
+}
+
+function assertVisible(element) {
+  try {
+    if (element === null) {
+      Qunit.assert.notEqual(element, null);
+      return;
+    }
+
+    Qunit.assert.dom(element).doesNotHaveAttribute('hidden');
+    Qunit.assert.dom(element).doesNotHaveStyle({ display: 'none' });
+  } catch (err) {
+    Error.captureStackTrace(err, assertVisible);
+    throw err;
+  }
+}
+
+function assertDialog(options, dialog = getDialog()) {
+  options.attributes = options.attributes ?? {};
+
+  if (!options.state) {
+    Qunit.assert.notEqual(
+      options.state,
+      undefined,
+      'You must provide an expected `state`'
+    );
+
+    return;
+  }
+
+  try {
+    switch (options.state) {
+      case DialogState.InvisibleHidden: {
+        if (dialog === null) {
+          Qunit.assert.notEqual(dialog, null);
+
+          return;
+        }
+
+        assertHidden(dialog);
+
+        Qunit.assert.dom(dialog).hasAttribute('role', 'dialog');
+        Qunit.assert.dom(dialog).doesNotHaveAttribute('aria-modal');
+
+        if (options.textContent) {
+          Qunit.assert.dom(dialog).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert.dom(dialog).hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.Visible: {
+        if (dialog === null) {
+          Qunit.assert.notEqual(dialog, null);
+
+          return;
+        }
+
+        assertVisible(dialog);
+
+        Qunit.assert.dom(dialog).hasAttribute('role', 'dialog');
+        Qunit.assert.dom(dialog).hasAttribute('aria-modal', 'true');
+
+        if (options.textContent) {
+          Qunit.assert.dom(dialog).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert.dom(dialog).hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.InvisibleUnmounted: {
+        Qunit.assert.equal(dialog, null);
+        break;
+      }
+
+      default: {
+        assertNever(options.state);
+      }
+    }
+  } catch (err) {
+    Error.captureStackTrace(err, assertDialog);
+    throw err;
+  }
+}
+
+function assertDialogOverlay(options, overlay = getDialogOverlay()) {
+  options.attributes = options.attributes ?? {};
+
+  if (!options.state) {
+    Qunit.assert.notEqual(
+      options.state,
+      undefined,
+      'You must provide an expected `state`'
+    );
+
+    return;
+  }
+
+  try {
+    switch (options.state) {
+      case DialogState.InvisibleHidden: {
+        if (overlay === null) {
+          Qunit.assert.notEqual(overlay, null);
+
+          return;
+        }
+
+        assertHidden(overlay);
+
+        if (options.textContent) {
+          Qunit.assert.dom(overlay).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert.dom(overlay).hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.Visible: {
+        if (overlay === null) {
+          Qunit.assert.notEqual(overlay, null);
+
+          return;
+        }
+
+        assertVisible(overlay);
+
+        if (options.textContent) {
+          Qunit.assert.dom(overlay).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert.dom(overlay).hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.InvisibleUnmounted: {
+        Qunit.assert.equal(overlay, null);
+
+        break;
+      }
+
+      default: {
+        assertNever(options.state);
+      }
+    }
+  } catch (err) {
+    Error.captureStackTrace(err, assertDialogOverlay);
+    throw err;
+  }
+}
+
+function assertDialogTitle(
+  options,
+  title = getDialogTitle(),
+  dialog = getDialog()
+) {
+  options.attributes = options.attributes ?? {};
+
+  if (!options.state) {
+    Qunit.assert.notEqual(
+      options.state,
+      undefined,
+      'You must provide an expected `state`'
+    );
+
+    return;
+  }
+
+  try {
+    switch (options.state) {
+      case DialogState.InvisibleHidden: {
+        if (title === null) {
+          Qunit.assert.notEqual(title, null);
+
+          return;
+        }
+
+        if (dialog === null) {
+          Qunit.assert.notEqual(dialog, null);
+
+          return;
+        }
+
+        assertHidden(title);
+
+        Qunit.assert.dom(title).hasAttribute('id');
+        Qunit.assert.dom(dialog).hasAttribute('aria-labelledby', title.id);
+
+        if (options.textContent) {
+          Qunit.assert.dom(title).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert.dom(title).hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.Visible: {
+        if (title === null) {
+          Qunit.assert.notEqual(title, null);
+
+          return;
+        }
+
+        if (dialog === null) {
+          Qunit.assert.notEqual(dialog, null);
+
+          return;
+        }
+
+        assertVisible(title);
+
+        Qunit.assert.dom(title).hasAttribute('id');
+        Qunit.assert.dom(dialog).hasAttribute('aria-labelledby', title.id);
+
+        if (options.textContent) {
+          Qunit.assert.dom(title).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert.dom(title).hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.InvisibleUnmounted: {
+        Qunit.assert.equal(title, null);
+
+        break;
+      }
+
+      default: {
+        assertNever(options.state);
+      }
+    }
+  } catch (err) {
+    Error.captureStackTrace(err, assertDialogTitle);
+    throw err;
+  }
+}
+
+function assertDialogDescription(
+  options,
+  description = getDialogDescription(),
+  dialog = getDialog()
+) {
+  options.attributes = options.attributes ?? {};
+
+  if (!options.state) {
+    Qunit.assert.notEqual(
+      options.state,
+      undefined,
+      'You must provide an expected `state`'
+    );
+
+    return;
+  }
+
+  try {
+    switch (options.state) {
+      case DialogState.InvisibleHidden: {
+        if (description === null) {
+          Qunit.assert.notEqual(description, null);
+
+          return;
+        }
+
+        if (dialog === null) {
+          Qunit.assert.notEqual(dialog, null);
+
+          return;
+        }
+
+        assertHidden(description);
+
+        Qunit.assert.dom(description).hasAttribute('id');
+        Qunit.assert
+          .dom(dialog)
+          .hasAttribute('aria-describedby', description.id);
+
+        if (options.textContent) {
+          Qunit.assert.dom(description).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert
+            .dom(description)
+            .hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.Visible: {
+        if (description === null) {
+          Qunit.assert.notEqual(description, null);
+
+          return;
+        }
+
+        if (dialog === null) {
+          Qunit.assert.notEqual(dialog, null);
+
+          return;
+        }
+
+        assertVisible(description);
+
+        Qunit.assert.dom(description).hasAttribute('id');
+        Qunit.assert
+          .dom(dialog)
+          .hasAttribute('aria-describedby', description.id);
+
+        if (options.textContent) {
+          Qunit.assert.dom(description).hasText(options.textContent);
+        }
+
+        for (let attributeName in options.attributes) {
+          let attributeValue = options.attributes[attributeName];
+
+          if (attributeName === 'class') {
+            attributeValue = `ember-view ${attributeValue}`;
+          }
+
+          if (attributeName === 'id') {
+            attributeValue = new RegExp(`${attributeValue}$`);
+          }
+
+          Qunit.assert
+            .dom(description)
+            .hasAttribute(attributeName, attributeValue);
+        }
+
+        break;
+      }
+
+      case DialogState.InvisibleUnmounted: {
+        Qunit.assert.equal(description, null);
+
+        break;
+      }
+
+      default: {
+        assertNever(options.state);
+      }
+    }
+  } catch (err) {
+    Error.captureStackTrace(err, assertDialogDescription);
+    throw err;
+  }
+}
+
+function getByText(text) {
+  let walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode(node) {
+        if (node.children.length > 0) return NodeFilter.FILTER_SKIP;
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    }
+  );
+
+  while (walker.nextNode()) {
+    if (walker.currentNode.textContent.trim() === text)
+      return walker.currentNode;
+  }
+
+  return null;
+}
+
+export {
+  DialogState,
+  assertDialog,
+  assertDialogDescription,
+  assertDialogOverlay,
+  assertDialogTitle,
+  getDialog,
+  getDialogOverlay,
+  assertActiveElement,
+  getByText,
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -17,4 +17,9 @@ Router.map(function () {
   this.route('switch', function () {
     this.route('switch-basic');
   });
+
+  this.route('dialog', function () {
+    this.route('dialog-modal');
+    this.route('dialog-slide-over');
+  });
 });

--- a/tests/dummy/app/templates/dialog/dialog-modal.hbs
+++ b/tests/dummy/app/templates/dialog/dialog-modal.hbs
@@ -1,0 +1,63 @@
+<div class="flex items-start justify-center w-screen h-full p-12 bg-gray-50">
+  {{#let (hash isOpen=false) as |state|}}
+    <button
+      type="button"
+      class="inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      {{on "click" (set state.isOpen true)}}
+    >
+      Open dialog
+    </button>
+
+    <Dialog
+      class="fixed inset-0 z-10 overflow-y-auto"
+      @as="div"
+      @isOpen={{state.isOpen}}
+      @onClose={{set state.isOpen false}}
+      as |dialog|
+    >
+      <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+        <dialog.Overlay class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+
+        {{!-- This element is to trick the browser into centering the modal contents. --}}
+        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
+          &#8203;
+        </span>
+
+        <div class="inline-block px-4 pt-5 pb-4 overflow-hidden text-left align-bottom bg-white rounded-lg shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6">
+          <div>
+            <div class="flex items-center justify-center w-12 h-12 mx-auto bg-green-100 rounded-full">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+
+            <div class="mt-3 text-center sm:mt-5">
+              <dialog.Title
+                class="text-lg font-medium text-gray-900 leading-6"
+                @as="h3"
+              >
+                Payment successful
+              </dialog.Title>
+
+              <div class="mt-2">
+                <p class="text-sm text-gray-500">
+                  Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequatur amet labore.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5 sm:mt-6">
+            <button
+              type="button"
+              class="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm"
+              {{on "click" dialog.onClose}}
+            >
+                Go back to dashboard
+            </button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  {{/let}}
+</div>

--- a/tests/dummy/app/templates/dialog/dialog-slide-over.hbs
+++ b/tests/dummy/app/templates/dialog/dialog-slide-over.hbs
@@ -1,0 +1,177 @@
+<div class="flex items-start justify-center w-screen h-full p-12 bg-gray-50">
+  {{#let (hash isOpen=false) as |state|}}
+
+    <button
+      type="button"
+      class="inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      {{on "click" (set state.isOpen true)}}
+    >
+      Open dialog
+    </button>
+
+    <Dialog
+      class="fixed inset-0 overflow-hidden"
+      @as="div"
+      @isOpen={{state.isOpen}}
+      @onClose={{set state.isOpen false}}
+      as |dialog|
+    >
+      <div class="absolute inset-0 overflow-hidden">
+        <dialog.Overlay class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+
+        <div class="fixed inset-y-0 right-0 flex max-w-full pl-10">
+          <div class="relative w-96">
+            <div class="absolute top-0 left-0 flex pt-4 pr-2 -ml-8 sm:-ml-10 sm:pr-4">
+              <button
+                type="button"
+                class="text-gray-300 rounded-md hover:text-white focus:outline-none focus:ring-2 focus:ring-white"
+                {{on "click" dialog.onClose}}
+              >
+                <span class="sr-only">Close panel</span>
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div class="h-full p-8 overflow-y-auto bg-white">
+              <div class="pb-16 space-y-6">
+                <div>
+                  <div class="block w-full overflow-hidden rounded-lg aspect-w-10 aspect-h-7">
+                    <img
+                      src="https://images.unsplash.com/photo-1582053433976-25c00369fc93?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=512&q=80"
+                      alt="cheese"
+                      class="object-cover"
+                    />
+                  </div>
+                  <div class="flex items-start justify-between mt-4">
+                    <div>
+                      <h2 class="text-lg font-medium text-gray-900">
+                        <span class="sr-only">Details for </span>IMG_4985.HEIC
+                      </h2>
+                      <p class="text-sm font-medium text-gray-500">3.9 MB</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="flex items-center justify-center w-8 h-8 ml-4 text-gray-400 bg-white rounded-full hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                      </svg>
+                      <span class="sr-only">Favorite</span>
+                    </button>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="font-medium text-gray-900">Information</h3>
+                  <dl class="mt-2 border-t border-b border-gray-200 divide-y divide-gray-200">
+                    <div class="flex justify-between py-3 text-sm font-medium">
+                      <dt class="text-gray-500">Uploaded by</dt>
+                      <dd class="text-gray-900">Marie Culver</dd>
+                    </div>
+                    <div class="flex justify-between py-3 text-sm font-medium">
+                      <dt class="text-gray-500">Created</dt>
+                      <dd class="text-gray-900">June 8, 2020</dd>
+                    </div>
+                    <div class="flex justify-between py-3 text-sm font-medium">
+                      <dt class="text-gray-500">Last modified</dt>
+                      <dd class="text-gray-900">June 8, 2020</dd>
+                    </div>
+                    <div class="flex justify-between py-3 text-sm font-medium">
+                      <dt class="text-gray-500">Dimensions</dt>
+                      <dd class="text-gray-900">4032 x 3024</dd>
+                    </div>
+                    <div class="flex justify-between py-3 text-sm font-medium">
+                      <dt class="text-gray-500">Resolution</dt>
+                      <dd class="text-gray-900">72 x 72</dd>
+                    </div>
+                  </dl>
+                </div>
+                <div>
+                  <h3 class="font-medium text-gray-900">Description</h3>
+                  <div class="flex items-center justify-between mt-2">
+                    <p class="text-sm italic text-gray-500">Add a description to this image.</p>
+                    <button
+                      type="button"
+                      class="flex items-center justify-center w-8 h-8 -mr-2 text-gray-400 bg-white rounded-full hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                      </svg>
+                      <span class="sr-only">Add description</span>
+                    </button>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="font-medium text-gray-900">Shared with</h3>
+                  <ul class="mt-2 border-t border-b border-gray-200 divide-y divide-gray-200">
+                    <li class="flex items-center justify-between py-3">
+                      <div class="flex items-center">
+                        <img
+                          src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?ixlib=rb-=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=3&w=1024&h=1024&q=80"
+                          alt="cheese"
+                          class="w-8 h-8 rounded-full"
+                        />
+                        <p class="ml-4 text-sm font-medium text-gray-900">Aimee Douglas</p>
+                      </div>
+                      <button
+                          type="button"
+                          class="ml-6 text-sm font-medium text-indigo-600 bg-white rounded-md hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                          >
+                          Remove<span class="sr-only"> Aimee Douglas</span>
+                      </button>
+                    </li>
+                    <li class="flex items-center justify-between py-3">
+                      <div class="flex items-center">
+                        <img
+                          src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixqx=oilqXxSqey&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                          alt="cheese"
+                          class="w-8 h-8 rounded-full"
+                        />
+                        <p class="ml-4 text-sm font-medium text-gray-900">Andrea McMillan</p>
+                      </div>
+                      <button
+                        type="button"
+                        class="ml-6 text-sm font-medium text-indigo-600 bg-white rounded-md hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      >
+                        Remove<span class="sr-only"> Andrea McMillan</span>
+                      </button>
+                    </li>
+                    <li class="flex items-center justify-between py-2">
+                      <button
+                        type="button"
+                        class="flex items-center p-1 -ml-1 bg-white group rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      >
+                        <span class="flex items-center justify-center w-8 h-8 text-gray-400 border-2 border-gray-300 border-dashed rounded-full">
+                          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clip-rule="evenodd" />
+                          </svg>
+                        </span>
+                        <span class="ml-4 text-sm font-medium text-indigo-600 group-hover:text-indigo-500">
+                          Share
+                        </span>
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+                <div class="flex">
+                  <button
+                    type="button"
+                    class="flex-1 px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                  >
+                    Download
+                  </button>
+                    <button
+                      type="button"
+                      class="flex-1 px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    >
+                      Delete
+                    </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  {{/let}}
+</div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -29,6 +29,17 @@
           </li>
         </ul>
       </li>
+      <li>
+        <h3 class="text-xl">Dialog</h3>
+        <ul>
+          <li>
+            <a href="/dialog/dialog-modal">Dialog (modal)</a>
+          </li>
+          <li>
+            <a href="/dialog/dialog-slide-over">Dialog (slide over)</a>
+          </li>
+        </ul>
+      </li>
     </ul>
 
   </div>

--- a/tests/integration/components/dialog-test.js
+++ b/tests/integration/components/dialog-test.js
@@ -1,0 +1,502 @@
+import { module, test, todo } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, setupOnerror } from '@ember/test-helpers';
+import triggerKeyEvent from '@ember/test-helpers/dom/trigger-key-event';
+import { hbs } from 'ember-cli-htmlbars';
+
+import { Keys } from 'ember-headlessui/utils/keyboard';
+
+import {
+  DialogState,
+  assertDialog,
+  assertDialogDescription,
+  assertDialogOverlay,
+  assertDialogTitle,
+  getDialog,
+  getDialogOverlay,
+  assertActiveElement,
+  getByText,
+} from '../../accessibility-assertions';
+
+module('Integration | Component | <Dialog>', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('Safe guards', function () {
+    test('should error when we are using a <Dialog::-Overlay /> without a parent <Dialog />', async function (assert) {
+      setupOnerror(function (err) {
+        assert.equal(
+          err.message,
+          '<Dialog::-Overlay /> is missing a parent <Dialog /> component.',
+          'Throw initialization error'
+        );
+      });
+
+      await render(hbs`<Dialog::-Overlay />`);
+    });
+
+    test('should error when we are using a <Dialog::-Title /> without a parent <Dialog />', async function (assert) {
+      setupOnerror(function (err) {
+        assert.equal(
+          err.message,
+          '<Dialog::-Title /> is missing a parent <Dialog /> component.',
+          'Throw initialization error'
+        );
+      });
+
+      await render(hbs`<Dialog::-Title />`);
+    });
+
+    test('should error when we are using a <Dialog::-Description /> without a parent <Dialog />', async function (assert) {
+      setupOnerror(function (err) {
+        assert.equal(
+          err.message,
+          '<Dialog::-Description /> is missing a parent <Dialog /> component.',
+          'Throw initialization error'
+        );
+      });
+
+      await render(hbs`<Dialog::-Description />`);
+    });
+
+    test('it should be possible to render a Dialog without crashing', async function () {
+      this.set('noop', function () {});
+
+      await render(hbs`
+        <Dialog
+          @isOpen={{false}}
+          @onClose={{this.noop}}
+          as |d|
+        >
+          <button type="button">Trigger</button>
+          <d.Overlay />
+          <d.Title />
+          <p>Contents</p>
+          <d.Description />
+        </Dialog>
+      `);
+
+      assertDialog({ state: DialogState.InvisibleUnmounted });
+    });
+  });
+
+  module('Rendering', function () {
+    module('Dialog', function () {
+      test('it should complain when the `isOpen` and `onClose` prop are missing', async function (assert) {
+        setupOnerror(function (err) {
+          assert.equal(
+            err.message,
+            'You have to provide an `isOpen` and an `onClose` prop to the `Dialog` component.',
+            'Throw initialization error'
+          );
+        });
+
+        await render(hbs`<Dialog @as="div" />`);
+      });
+
+      test('it should complain when an `isOpen` prop is provided without an `onClose` prop', async function (assert) {
+        setupOnerror(function (err) {
+          assert.equal(
+            err.message,
+            'You provided an `isOpen` prop to the `Dialog`, but forgot an `onClose` prop.',
+            'Throw initialization error'
+          );
+        });
+
+        await render(hbs`<Dialog @as="div" @isOpen={{false}} />`);
+      });
+
+      test('it should complain when an `onClose` prop is provided without an `isOpen` prop', async function (assert) {
+        this.set('noop', function () {});
+
+        setupOnerror(function (err) {
+          assert.equal(
+            err.message,
+            'You provided an `onClose` prop to the `Dialog`, but forgot an `isOpen` prop.',
+            'Throw initialization error'
+          );
+        });
+
+        await render(hbs`<Dialog @as="div" @onClose={{this.noop}}/>`);
+      });
+
+      test('it should complain when an `isOpen` prop is not a boolean', async function (assert) {
+        this.set('noop', function () {});
+
+        setupOnerror(function (err) {
+          assert.equal(
+            err.message,
+            'You provided an `isOpen` prop to the `Dialog`, but the value is not a boolean. Received: null',
+            'Validate the type of the `isOpen` arg'
+          );
+        });
+
+        await render(
+          hbs`<Dialog @as="div" @isOpen={{null}} @onClose={{this.noop}}/>`
+        );
+      });
+
+      test('it should complain when an `onClose` prop is not a function', async function (assert) {
+        setupOnerror(function (err) {
+          assert.equal(
+            err.message,
+            'You provided an `onClose` prop to the `Dialog`, but the value is not a function. Received: null',
+            'Validate the type of the `onClose` arg'
+          );
+        });
+
+        await render(
+          hbs`<Dialog @as="div" @isOpen={{false}} @onClose={{null}}/>`
+        );
+      });
+
+      test('it should be possible to render a Dialog using a render prop', async function () {
+        this.set('isOpen', false);
+
+        await render(hbs`
+          <button id="trigger" type="button" {{on "click" (set this.isOpen true)}}>
+            Trigger
+          </button>
+          <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}}>
+            <pre>Hello</pre>
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assertDialog({ state: DialogState.InvisibleUnmounted });
+
+        await click(document.getElementById('trigger'));
+
+        assertDialog({ state: DialogState.Visible, textContent: 'Hello' });
+      });
+
+      test('it should be possible to pass props to the Dialog itself', async function () {
+        this.set('isOpen', false);
+
+        await render(hbs`
+          <button id="trigger" type="button" {{on "click" (set this.isOpen true)}}>
+            Trigger
+          </button>
+          <Dialog
+            class="relative bg-blue-500"
+            @isOpen={{this.isOpen}}
+            @onClose={{set this.isOpen false}}
+          >
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assertDialog({ state: DialogState.InvisibleUnmounted });
+
+        await click(document.getElementById('trigger'));
+
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { class: 'relative bg-blue-500' },
+        });
+      });
+
+      todo(
+        'it should be possible to always render the Dialog if we provide it a `static` prop (and enable focus trapping based on `isOpen`)',
+        async function () {}
+      );
+
+      todo(
+        'it should be possible to always render the Dialog if we provide it a `static` prop (and disable focus trapping based on `isOpen`)',
+        async function () {}
+      );
+
+      todo(
+        'it should be possible to use a different render strategy for the Dialog',
+        async function () {}
+      );
+
+      todo('it should add a scroll lock to the html tag', async function () {});
+    });
+
+    module('Dialog.Overlay', function () {
+      test('it should be possible to render Dialog.Overlay using a render prop', async function () {
+        this.set('isOpen', false);
+
+        await render(hbs`
+          <button id="trigger" type="button" {{on "click" (set this.isOpen true)}}>
+            Trigger
+          </button>
+          <Dialog
+            class="relative bg-blue-500"
+            @isOpen={{this.isOpen}}
+            @onClose={{set this.isOpen false}}
+            as |d|
+          >
+            <d.Overlay>Hello</d.Overlay>
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assertDialogOverlay({ state: DialogState.InvisibleUnmounted });
+
+        await click(document.getElementById('trigger'));
+
+        assertDialogOverlay({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-overlay' },
+          textContent: 'Hello',
+        });
+      });
+    });
+
+    module('Dialog.Title', function () {
+      test('it should be possible to render Dialog.Title using a render prop', async function () {
+        this.set('noop', function () {});
+
+        await render(hbs`
+          <Dialog @isOpen={{true}} @onClose={{this.noop}} as |d|>
+            <d.Title>Hello</d.Title>
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog' },
+        });
+
+        assertDialogTitle({
+          state: DialogState.Visible,
+          textContent: 'Hello',
+        });
+      });
+    });
+
+    module('Dialog.Description', function () {
+      test('it should be possible to render Dialog.Description using a render prop', async function () {
+        this.set('noop', function () {});
+
+        await render(hbs`
+          <Dialog @isOpen={{true}} @onClose={{this.noop}} as |d|>
+            <d.Description>Hello</d.Description>
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog' },
+        });
+
+        assertDialogDescription({
+          state: DialogState.Visible,
+          textContent: 'Hello',
+        });
+      });
+    });
+  });
+
+  module('Composition', function () {
+    todo(
+      'it should be possible to open the Dialog via a Transition component',
+      async function () {}
+    );
+
+    todo(
+      'it should be possible to close the Dialog via a Transition component',
+      async function () {}
+    );
+  });
+
+  module('Keyboard interactions', function () {
+    module('Escape key', function () {
+      test('it should be possible to close the dialog with Escape', async function () {
+        this.set('isOpen', false);
+
+        await render(hbs`
+          <button type="button" {{on "click" (set this.isOpen true)}}>
+            Trigger
+          </button>
+
+          <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}}>
+            Hello
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assertDialog({ state: DialogState.InvisibleUnmounted });
+
+        await click(getByText('Trigger'));
+
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog' },
+        });
+
+        await triggerKeyEvent(getDialog(), 'keyup', Keys.Escape);
+
+        assertDialog({ state: DialogState.InvisibleUnmounted });
+      });
+    });
+  });
+
+  module('Mouse interactions', function () {
+    test('it should be possible to close a Dialog using a click on the Dialog.Overlay', async function () {
+      this.set('isOpen', false);
+
+      await render(hbs`
+        <button type="button" {{on "click" (set this.isOpen true)}}>
+          Trigger
+        </button>
+
+        <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}} as |d|>
+          <d.Overlay />
+          Contents
+          <div tabindex="0"></div>
+        </Dialog>
+      `);
+
+      await click(getByText('Trigger'));
+
+      assertDialog({ state: DialogState.Visible });
+
+      await click(getDialogOverlay());
+
+      assertDialog({ state: DialogState.InvisibleUnmounted });
+    });
+
+    test('it should be possible to close the dialog, and re-focus the button when we click outside on the body element', async function () {
+      this.set('isOpen', false);
+
+      await render(hbs`
+        <button type="button" {{on "click" (set this.isOpen true)}}>
+          Trigger
+        </button>
+
+        <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}}>
+          Contents
+          <div tabindex="0"></div>
+        </Dialog>
+      `);
+
+      await click(getByText('Trigger'));
+
+      assertDialog({ state: DialogState.Visible });
+
+      await click(document.body);
+
+      assertDialog({ state: DialogState.InvisibleUnmounted });
+
+      assertActiveElement(getByText('Trigger'));
+    });
+
+    todo(
+      'it should be possible to close the dialog, and keep focus on the focusable element',
+      async function () {}
+    );
+
+    test('it should stop propagating click events when clicking on the Dialog.Overlay', async function (assert) {
+      this.set('isOpen', true);
+
+      let callCount = 0;
+
+      this.set('wrapperFn', function () {
+        callCount++;
+      });
+
+      await render(hbs`
+        {{!-- template-lint-disable no-invalid-interactive  --}}
+        <div {{on "click" this.wrapperFn}}>
+          <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}} as |d|>
+            Contents
+            <d.Overlay />
+            <div tabindex="0"></div>
+          </Dialog>
+        </div>
+      `);
+
+      assertDialog({ state: DialogState.Visible });
+
+      assert.equal(callCount, 0, 'Call count starts as zero');
+
+      await click(getDialogOverlay());
+
+      assertDialog({ state: DialogState.InvisibleUnmounted });
+
+      assert.equal(callCount, 0, 'Click has not propagated to wrapper element');
+    });
+
+    test('it should be possible to submit a form inside a Dialog', async function (assert) {
+      this.set('noop', function () {});
+
+      let callCount = 0;
+
+      this.set('submitFn', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        callCount++;
+      });
+
+      await render(hbs`
+        <Dialog @isOpen={{true}} @onClose={{this.noop}}>
+          <form {{on "submit" this.submitFn}}>
+            <input type="hidden" value="abc" />
+            <button type="submit">Submit</button>
+          </form>
+        </Dialog>
+      `);
+
+      assertDialog({ state: DialogState.Visible });
+
+      await click(getByText('Submit'));
+
+      assert.equal(callCount, 1, 'Form was able to be submitted');
+    });
+
+    test('it should stop propagating click events when clicking on an element inside the Dialog', async function (assert) {
+      this.set('isOpen', true);
+
+      let callCount = 0;
+
+      this.set('wrapperFn', function () {
+        callCount++;
+      });
+
+      await render(hbs`
+        {{!-- template-lint-disable no-invalid-interactive  --}}
+        <div {{on "click" this.wrapperFn}}>
+          <Dialog
+            @isOpen={{this.isOpen}}
+            @onClose={{set this.isOpen false}}
+            as |dialog|
+          >
+            Contents
+            <button type="button" {{on "click" dialog.onClose}}>Inside</button>
+          </Dialog>
+        </div>
+      `);
+
+      assertDialog({ state: DialogState.Visible });
+
+      assert.equal(callCount, 0, 'Call count starts at zero');
+
+      await click(getByText('Inside'));
+
+      assertDialog({ state: DialogState.InvisibleUnmounted });
+
+      assert.equal(callCount, 0, 'Click has not propagated out of Dialog');
+    });
+  });
+
+  module('Nesting', function () {
+    todo(
+      'it should be possible to open nested Dialog components and close them with `Escape`',
+      async function () {}
+    );
+
+    todo(
+      'it should be possible to open nested Dialog components and close them with `Outside Click`',
+      async function () {}
+    );
+
+    todo(
+      'it should be possible to open nested Dialog components and close them with `Click on Dialog.Overlay`',
+      async function () {}
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,6 +1887,31 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/macros@^0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.41.0.tgz#3e78b6f388d7229906abf4c75edfff8bb0208aca"
+  integrity sha512-QISzwEEfLsskZeL0jyZDs1RoQSotwBWj+4upTogNHuxQP5j/9H3IMG/3QB1gh8GEpbudATb/cS4NDYK3UBxufw==
+  dependencies:
+    "@embroider/shared-internals" "0.41.0"
+    assert-never "^1.1.0"
+    ember-cli-babel "^7.23.0"
+    lodash "^4.17.10"
+    resolve "^1.8.1"
+    semver "^7.3.2"
+
+"@embroider/shared-internals@0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.41.0.tgz#2553f026d4f48ea1fd11235501feb63bf49fa306"
+  integrity sha512-fiqUVB6cfh2UBEFE4yhT5EzagkZ1Q26+OhBV0nJszFEJZx4DqVIb3pxSSZ8P+HhpxuJsQ2XpMA/j02ZPFZfbdQ==
+  dependencies:
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^7.0.1"
+    lodash "^4.17.10"
+    pkg-up "^3.1.0"
+    resolve-package-path "^1.2.2"
+    semver "^7.3.2"
+    typescript-memoize "^1.0.0-alpha.3"
+
 "@embroider/test-setup@^0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.37.0.tgz#4c0590c8c3e45813dd53b8b551206acd0a49cefd"
@@ -6316,6 +6341,17 @@ ember-export-application-global@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
+ember-focus-trap@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-0.7.0.tgz#8c3fa66a0d393dad2994db82e2fa227103875fc0"
+  integrity sha512-WHOD8jTcCzsRb0cU8J5SKObrxbdD8rPSWrSUjZ2QYu9dVbaXg6/hZxcN5JrmPY1ArnsRaLMPdOUALYeZTP29og==
+  dependencies:
+    "@embroider/macros" "^0.41.0"
+    ember-auto-import "^1.11.2"
+    ember-cli-babel "^7.26.3"
+    ember-modifier-manager-polyfill "^1.2.0"
+    focus-trap "^6.4.0"
+
 ember-load-initializers@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz#8a47a656c1f64f9b10cecdb4e22a9d52ad9c7efa"
@@ -7508,6 +7544,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focus-trap@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.4.0.tgz#e9951484fddf933d9b9b0e95b499f9420f6a54d6"
+  integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
+  dependencies:
+    tabbable "^5.2.0"
 
 follow-redirects@^1.0.0:
   version "1.13.0"
@@ -12395,6 +12438,11 @@ sync-disk-cache@^2.0.0:
     mkdirp "^0.5.0"
     rimraf "^3.0.0"
     username-sync "^1.0.2"
+
+tabbable@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
+  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@^6.0.4:
   version "6.7.1"


### PR DESCRIPTION
# ✨ What Changed and Why

This PR introduces the `<Dialog />` component based on https://headlessui.dev/react/dialog

This PR implements the component by re-implementing the Vue tests ([LINK](https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-vue/src/components/dialog/dialog.test.ts)). Where I can mirror these tests I do, but not all of them  apply one-to-one with the Vue implementation. Where they do diverge, I stick with Ember idioms and practices to achieve a similar result.

This PR doesn't aim to implement every single aspect of the reference implementation. Just the core functionality to start using it. The things that this PR does implement are:

- Basic show and hide
- Implementing the `Dialog`, `Overlay`, `Title` and `Description` components
- Styling the Dialog and the Overlay
- Rendering in a portal
- Accessibility (focus management, mouse interaction, keyboard interaction, aria labels)

Things that this PR does not implement are:

- Specifying initial focus element
- `static` prop
- Composition with transitions
- Nesting of `<Dialog>`s

Below is a record of the reference implementation component API's and what has been implemented in this PR:

❌ === not implemented

## `<Dialog />`

### Props (Vue) / Args (Ember)
| Vue  | Ember |
| ------------- | ------------- |
| `open`  | `@open`  |
| `initialFocus`  | ❌  |
|`as`| `@as`|
|`static`|❌|
|`unmount`|❌|

### Events (Vue) / Actions (Ember)
| Vue  | Ember |
| ------------- | ------------- |
| `close`  | `@onClose`  |

### Slot props (Vue) / Yielded data (Ember)

| Vue  | Ember |
| ------------- | ------------- |
| `open`  | `open`  |


## `<Dialog.Overlay />`

### Props (Vue) / Args (Ember)
| Vue  | Ember |
| ------------- | ------------- |
| `as`  | `@as`  |

### Slot props (Vue) / Yielded data (Ember)

| Vue  | Ember |
| ------------- | ------------- |
| `open`  | `open`  |

## `<Dialog.Title />`

### Props (Vue) / Args (Ember)
| Vue  | Ember |
| ------------- | ------------- |
| `as`  | `@as`  |

### Slot props (Vue) / Yielded data (Ember)

| Vue  | Ember |
| ------------- | ------------- |
| `open`  | `open`  |

## `<Dialog.Description />`

### Props (Vue) / Args (Ember)
| Vue  | Ember |
| ------------- | ------------- |
| `as`  | `@as`  |

### Slot props (Vue) / Yielded data (Ember)

| Vue  | Ember |
| ------------- | ------------- |
| `open`  | `open`  |

# 😈 Before

Didn't exist

# 😇 After


https://user-images.githubusercontent.com/416724/120331990-37d67400-c2e6-11eb-8cdf-0a5d4ded706d.mov


Closes #28 