### PR TITLE
🐞 Fix error in consuming apps that can't find focus-trap

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-element-helper": "^0.3.1",
+    "ember-focus-trap": "^0.7.0",
     "ember-truth-helpers": "^2.1.0"
   },
   "devDependencies": {
@@ -52,7 +53,6 @@
     "ember-css-transitions": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
-    "ember-focus-trap": "^0.7.0",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-on-helper": "^0.1.0",


### PR DESCRIPTION
# ✨ What Changed and Why

Woops! #31 introduced a bug where by the following error occurs:

![image](https://user-images.githubusercontent.com/416724/120497689-894e3400-c3b6-11eb-827b-9f076cb4554c.png)

This was due to `ember-focus-trap` being in `devDependencies` instead of `dependencies`. This gets me every time 😬 

