### PR TITLE
Inject Dialog element into app root

### DIFF
--- a/addon/components/dialog.js
+++ b/addon/components/dialog.js
@@ -1,16 +1,24 @@
 import Component from '@glimmer/component';
 import { typeOf } from '@ember/utils';
 import { guidFor } from '@ember/object/internals';
+import { getOwnConfig } from '@embroider/macros';
 
 import { modifier } from 'ember-modifier';
 
 import { Keys } from 'ember-headlessui/utils/keyboard';
 
+function getPortalRoot() {
+  const { rootElement } = getOwnConfig();
+
+  // If we looked up a `rootElement` config at build-time, use that; otherwise use the body
+  return rootElement ? document.querySelector(rootElement) : document.body;
+}
+
 export default class DialogComponent extends Component {
   DEFAULT_TAG_NAME = 'div';
 
   guid = `${guidFor(this)}-headlessui-dialog`;
-  $portalRoot = document.body;
+  $portalRoot = getPortalRoot();
 
   handleEscapeKey = modifier((_element, [isOpen, onClose]) => {
     let handler = (event) => {

--- a/index.js
+++ b/index.js
@@ -2,4 +2,16 @@
 
 module.exports = {
   name: require('./package').name,
+
+  options: {
+    '@embroider/macros': {
+      setOwnConfig: {},
+    },
+  },
+
+  config(_emberEnv, config) {
+    // Pass `rootElement` config into a location where it can be looked up at run-time
+    this.options['@embroider/macros'].setOwnConfig.rootElement =
+      config.APP.rootElement;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
+    "@embroider/macros": "^0.41.0",
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-element-helper": "^0.3.1",


### PR DESCRIPTION
When checking out the `Dialog` element, I noticed an issue in the testing environment: you can't actually see the dialog.

This happens because the `Dialog` uses `document.body` as a target for the `in-element` helper. This works fine when the app is running normally, but in the testing environment places the `Dialog` outside of the testing window.

The result is that you can't visually _see_ the `Dialog`, in particular when using the `Dev Mode` feature of QUnit.

<img width="973" alt="CleanShot 2021-06-07 at 12 39 43@2x" src="https://user-images.githubusercontent.com/1645881/121058145-0817e800-c78e-11eb-8690-341a53fa60f6.png">

By looking up the `rootElement` configuration and using that instead, where available, we can place the `Dialog` element _inside_ the testing root, rather than adjacent to it, so the element is visible again

<img width="973" alt="CleanShot 2021-06-07 at 12 39 03@2x" src="https://user-images.githubusercontent.com/1645881/121058285-2b429780-c78e-11eb-9ab8-e423f7fa2ec9.png">

I pulled this off using `@embroider/macros` to look up the app's config option and make it available to the addon. There are other ways to do this, like `ember-get-config`, but from what I can tell using `@embroider/macros` is the recommended approach in a post-Embroider world.