### PR TITLE
chore: simplify `on` config for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   test:
@@ -20,7 +14,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: "**/node_modules"
+          path: '**/node_modules'
           key: ci-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: install dependencies


### PR DESCRIPTION
I noticed that #38 didn't run CI for some reason, which I've never seen before. I'm wondering if it's because of the specific branch filtering, so I'm trying to remove that to see if this will run CI for a fork PR instead. 