### PR TITLE
Deploy Docs Site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ci-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: dist

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -45,6 +45,7 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.rootURL = '/ember-headlessui';
   }
 
   return ENV;


### PR DESCRIPTION
First attempt at #42 

This might be a trial-and-error kind of situation if this doesn't work right off the bat, but I'm pretty sure this should be fine. I know that we can use `ember-cli-deploy` or something in here, as I do with `ember-steps` for example, but I honestly don't think it's necessary. Setting the right `rootURL` should be all we need to do, since this action handles actually putting the assets on the branch!

https://github.com/marketplace/actions/deploy-to-github-pages