### PR TITLE
Fix Docs Site Links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  test:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,9 +3,9 @@
     <header
       class="relative z-10 flex items-center justify-between flex-shrink-0 px-4 py-4 bg-gray-700 border-b border-gray-200 sm:px-6 lg:px-8"
     >
-      <a href="/">
+      <LinkTo @route="index">
         <Logo class="h-6" />
-      </a>
+      </LinkTo>
     </header>
     <main class="flex-1 overflow-auto bg-gray-50">
       {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -8,16 +8,16 @@
         <h3 class="text-xl">Menu</h3>
         <ul>
           <li>
-            <a href="/menu/menu-basic">Menu (basic)</a>
+            <LinkTo @route="menu.menu-basic">Menu (basic)</LinkTo>
           </li>
           <li>
-            <a href="/menu/menu-with-popper">Menu with Popper [todo]</a>
+            <LinkTo @route="menu.menu-with-popper">Menu with Popper [todo]</LinkTo>
           </li>
           <li>
-            <a href="/menu/menu-with-transition">Menu with Transition [todo]</a>
+            <LinkTo @route="menu.menu-with-transition">Menu with Transition [todo]</LinkTo>
           </li>
           <li>
-            <a href="/menu/menu-with-transition-and-popper">Menu with Popper + Transition [todo]</a>
+            <LinkTo @route="menu.menu-with-transition-and-popper">Menu with Popper + Transition [todo]</LinkTo>
           </li>
         </ul>
       </li>
@@ -25,7 +25,7 @@
         <h3 class="text-xl">Switch</h3>
         <ul>
           <li>
-            <a href="/switch/switch-basic">Switch (basic)</a>
+            <LinkTo @route="switch.switch-basic">Switch (basic)</LinkTo>
           </li>
         </ul>
       </li>
@@ -33,10 +33,10 @@
         <h3 class="text-xl">Dialog</h3>
         <ul>
           <li>
-            <a href="/dialog/dialog-modal">Dialog (modal)</a>
+            <LinkTo @route="dialog.dialog-modal">Dialog (modal)</LinkTo>
           </li>
           <li>
-            <a href="/dialog/dialog-slide-over">Dialog (slide over)</a>
+            <LinkTo @route="dialog.dialog-slide-over">Dialog (slide over)</LinkTo>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
This should fix the links not respecting the `rootURL` configuration that's needed for the GitHub Pages environment.

Additionally, I wasn't happy with the naming of the GitHub workflow/job for deploying the site, so I fixed that too!
