### PR TITLE
fix(switch): default to using a `button` element

### DIFF
--- a/addon/components/switch/button.hbs
+++ b/addon/components/switch/button.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or @tagName "div")) as |Tag|}}
+{{#let (element (or @tagName "button")) as |Tag|}}
   <Tag
     id={{@guid}}
     role="switch"

--- a/tests/integration/components/switch-test.js
+++ b/tests/integration/components/switch-test.js
@@ -85,7 +85,7 @@ module('Integration | Component | <Switch>', function (hooks) {
       assertSwitchState({
         state: SwitchState.On,
         text: 'On',
-        buttonTagName: 'div',
+        buttonTagName: 'button',
       });
       assert.dom('[data-test-switch]').hasTagName('div');
     });
@@ -101,7 +101,7 @@ module('Integration | Component | <Switch>', function (hooks) {
       assertSwitchState({
         state: SwitchState.Off,
         text: 'Off',
-        buttonTagName: 'div',
+        buttonTagName: 'button',
       });
     });
 


### PR DESCRIPTION
I've been checking out the `Switch` component and noticed a difference between the behavior here and in the "real" version of HeadlessUI. In the React and Vue components, the actual switch itself defaults to a `button` but can be overwritten to something else. Here, the default is a `div`!

The documentation on the Switch is a little hard to compare 1:1 to the Ember version, but if you look here

https://headlessui.dev/react/switch#switch

it mentions that the default tag is a `button`. Looking at the actual example of a switch in the docs site, it's indeed a `button` under-the-hood!