### PR TITLE
docs(switch): add example of building a checkbox

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function () {
 
   this.route('switch', function () {
     this.route('switch-basic');
+    this.route('switch-checkbox');
   });
 
   this.route('dialog', function () {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -27,6 +27,9 @@
           <li>
             <LinkTo @route="switch.switch-basic">Switch (basic)</LinkTo>
           </li>
+          <li>
+            <LinkTo @route="switch.switch-checkbox">Switch (checkbox)</LinkTo>
+          </li>
         </ul>
       </li>
       <li>

--- a/tests/dummy/app/templates/switch/switch-checkbox.hbs
+++ b/tests/dummy/app/templates/switch/switch-checkbox.hbs
@@ -1,0 +1,22 @@
+<div class="flex items-start justify-center w-screen h-full p-12 bg-gray-50">
+  <Switch
+    @isOn={{this.isOn}}
+    @onUpdate={{set this.isOn}}
+    class="flex items-center space-x-4"
+    as |switch|
+  >
+    <switch.Button
+      class="
+        h-6 w-6 rounded border-2
+        {{if switch.isOn "border-indigo-700" "border-gray-300"}}
+      "
+      role="checkbox"
+    >
+      <div class="
+        h-full w-full transition duration-200
+        {{if switch.isOn "bg-indigo-600" "bg-gray-200"}}
+      " />
+    </switch.Button>
+    <switch.Label>Enable notifications</switch.Label>
+  </Switch>
+</div>


### PR DESCRIPTION
I realized after checking out the `Switch` component that it's a great candidate for the foundation of a custom-styled checkbox! Since you can't style an `input[type="checkbox"]` natively and have to build something custom, building on top of `Switch` helped me get the accessibility requirements correct.

All of the `aria` behavior for a switch and a checkbox are the same, save the `role="checkbox"` on the button instead of the default `role="switch"`. That's easy to override in the implementation, though, since you can override default attributes!

I figured this might be a useful "cookbook" example for people since the Headless UI example doesn't show usage as a checkbox, and it's worth demonstrating how `switch.Button` can/should override the `role` attribute.

Here are the two states

<img width="935" alt="CleanShot 2021-06-11 at 11 16 05@2x" src="https://user-images.githubusercontent.com/1645881/121709586-b382ae80-caa6-11eb-8536-3a8b512eefc3.png">

<img width="935" alt="CleanShot 2021-06-11 at 11 16 06@2x" src="https://user-images.githubusercontent.com/1645881/121709591-b54c7200-caa6-11eb-863e-93c1b8559963.png">
