### PR TITLE
`Menu` Component Improvements

### DIFF
--- a/addon/components/menu.hbs
+++ b/addon/components/menu.hbs
@@ -1,42 +1,34 @@
-<div
-  id={{this.guid}}
-  ...attributes
-  {{on 'pointerdown' this.onPointerDown}}
-  {{click-outside this.close event='mouseup'}}
->
-  {{yield
-    (hash
+{{yield
+  (hash
+    isOpen=this.isOpen
+    Button=(component
+      'menu/button'
+      buttonGuid=this.buttonGuid
+      itemsGuid=this.itemsGuid
       isOpen=this.isOpen
-      Button=(component
-        'menu/button'
-        guid=this.buttonGuid
-        menuGuid=this.guid
-        itemsGuid=this.itemsGuid
-        isOpen=this.isOpen
-        onClick=this.toggle
-        openMenu=this.open
-        closeMenu=this.close
-        goToFirstItem=this.goToFirstItem
-        goToLastItem=this.goToLastItem
-        goToNextItem=this.goToNextItem
-        goToPreviousItem=this.goToPreviousItem
-      )
-      Items=(component
-        'menu/items'
-        guid=this.itemsGuid
-        buttonGuid=this.buttonGuid
-        isOpen=this.isOpen
-        closeMenu=this.close
-        activeItem=this.activeItem
-        registerItem=this.registerItem
-        unregisterItem=this.unregisterItem
-        goToFirstItem=this.goToFirstItem
-        goToLastItem=this.goToLastItem
-        goToNextItem=this.goToNextItem
-        goToPreviousItem=this.goToPreviousItem
-        goToItem=this.goToItem
-        search=(perform this.searchTask)
-      )
+      openMenu=this.open
+      closeMenu=this.close
+      toggleMenu=this.toggle
+      goToFirstItem=this.goToFirstItem
+      goToLastItem=this.goToLastItem
+      goToNextItem=this.goToNextItem
+      goToPreviousItem=this.goToPreviousItem
     )
-  }}
-</div>
+    Items=(component
+      'menu/items'
+      buttonGuid=this.buttonGuid
+      itemsGuid=this.itemsGuid
+      isOpen=this.isOpen
+      closeMenu=this.close
+      activeItem=this.activeItem
+      registerItem=this.registerItem
+      unregisterItem=this.unregisterItem
+      goToFirstItem=this.goToFirstItem
+      goToLastItem=this.goToLastItem
+      goToNextItem=this.goToNextItem
+      goToPreviousItem=this.goToPreviousItem
+      goToItem=this.goToItem
+      search=(perform this.searchTask)
+    )
+  )
+}}

--- a/addon/components/menu.js
+++ b/addon/components/menu.js
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { guidFor } from '@ember/object/internals';
-import { next } from '@ember/runloop';
 
 export default class Menu extends Component {
   guid = `${guidFor(this)}-tailwindui-menu`;
@@ -32,12 +31,7 @@ export default class Menu extends Component {
 
   @action
   close() {
-    if (this.isOpen) {
-      this.isOpen = false;
-      next(() => {
-        this.buttonElement && this.buttonElement.focus();
-      });
-    }
+    this.isOpen = false;
   }
 
   @action
@@ -122,16 +116,6 @@ export default class Menu extends Component {
     let index = items.indexOf(item);
     items.splice(index, 1);
     this.items = items;
-  }
-
-  @action
-  onPointerDown(event) {
-    if (event.defaultPrevented) return;
-    if (!this.isOpen) return;
-
-    next(() => {
-      this.buttonElement.focus();
-    });
   }
 
   _setActiveItem(item) {

--- a/addon/components/menu/button.hbs
+++ b/addon/components/menu/button.hbs
@@ -3,9 +3,9 @@
   aria-haspopup={{true}}
   aria-controls={{@itemsGuid}}
   aria-expanded={{@isOpen}}
-  id='{{@menuGuid}}-button'
+  id={{@buttonGuid}}
   ...attributes
-  {{on 'click' @onClick}}
+  {{on 'click' @toggleMenu}}
   {{on 'keydown' this.onKeydown}}
 >
   {{yield}}

--- a/addon/components/menu/items.hbs
+++ b/addon/components/menu/items.hbs
@@ -1,12 +1,21 @@
 {{#if @isOpen}}
   <div
-    id={{@guid}}
+    id={{@itemsGuid}}
     aria-labelledby={{@buttonGuid}}
     aria-activedescendant={{@activeItem.element.id}}
     tabindex='-1'
     role='menu'
     ...attributes
     {{on 'keydown' this.onKeydown}}
+    {{focus-trap
+      focusTrapOptions=(hash
+        allowOutsideClick=this.allowClickOutsideFocusTrap
+        clickOutsideDeactivates=this.clickOutsideFocusTrapDeactivates
+        fallbackFocus=this.menuItemsElement
+        initialFocus=this.menuItemsElement
+        onDeactivate=@closeMenu
+      )
+    }}
   >
     {{yield
       (hash

--- a/addon/components/menu/items.js
+++ b/addon/components/menu/items.js
@@ -2,6 +2,10 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class Items extends Component {
+  get menuItemsElement() {
+    return document.getElementById(this.args.itemsGuid);
+  }
+
   @action
   onKeydown(event) {
     switch (event.key) {
@@ -21,5 +25,22 @@ export default class Items extends Component {
           return this.args.search(event.key);
         }
     }
+  }
+
+  clickInsideMenuTrigger(event) {
+    const buttonElement = document.getElementById(this.args.buttonGuid);
+
+    // The `buttonElement` could not exist if the element has been removed from the DOM
+    return buttonElement ? buttonElement.contains(event.target) : false;
+  }
+
+  @action
+  allowClickOutsideFocusTrap(event) {
+    return this.clickInsideMenuTrigger(event);
+  }
+
+  @action
+  clickOutsideFocusTrapDeactivates(event) {
+    return !this.clickInsideMenuTrigger(event);
   }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/tests/integration/components/menu-test.js
+++ b/tests/integration/components/menu-test.js
@@ -60,19 +60,6 @@ function assertMenuLinkedWithMenuItem(item, menu = getMenu()) {
     .hasAria('activedescendant', itemElement.getAttribute('id'));
 }
 
-function assertMenuItems(menuSelector, expectedCount) {
-  let itemsSelector = `${menuSelector} [role="menuitem"]`;
-  QUnit.assert.dom(itemsSelector).exists({ count: expectedCount });
-
-  let itemElements = findAll(itemsSelector);
-
-  itemElements.forEach((itemElement) => {
-    QUnit.assert.dom(itemElement).hasAttribute('id');
-    QUnit.assert.dom(itemElement).hasAttribute('role', 'menuitem');
-    QUnit.assert.dom(itemElement).hasAttribute('tabindex', '-1');
-  });
-}
-
 function assertMenuItemsAreCollaped(selector) {
   QUnit.assert.dom(selector).isNotVisible();
 }
@@ -100,7 +87,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
   test('it renders', async (assert) => {
     await render(hbs`
-      <Menu data-test-menu as |menu|>
+      <Menu as |menu|>
         <menu.Button data-test-menu-button>Trigger</menu.Button>
         <menu.Items data-test-menu-items as |items|>
           <items.Item>Item A</items.Item>
@@ -109,8 +96,6 @@ module('Integration | Component | <Menu>', (hooks) => {
         </menu.Items>
       </Menu>
     `);
-
-    assert.dom('[data-test-menu]').isVisible();
 
     assert.dom('[data-test-menu-button]').hasText('Trigger');
 
@@ -123,7 +108,7 @@ module('Integration | Component | <Menu>', (hooks) => {
     module('Menu', () => {
       test('Menu yields an object', async (assert) => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger {{if menu.isOpen "visible" "hidden" }}</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item>Item A</items.Item>
@@ -147,7 +132,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('Item yields an object', async function (assert) {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger {{if menu.isOpen "visible" "hidden" }}</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -172,9 +157,9 @@ module('Integration | Component | <Menu>', (hooks) => {
 
   module('Keyboard interactions', function () {
     module('`Enter` key', function () {
-      test('it should be possible to open the menu with Enter', async () => {
+      test('it should be possible to open the menu with Enter', async (assert) => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -207,16 +192,16 @@ module('Integration | Component | <Menu>', (hooks) => {
           '[data-test-menu-items]'
         );
 
-        assertMenuItems('[data-test-menu]', 3);
-
         const items = getMenuItems();
+
+        assert.equal(items.length, 3, 'There are three visible menu items');
 
         assertMenuLinkedWithMenuItem(items[0]);
       });
 
       test('it should have no active menu item when there are no menu items at all', async () => {
         await render(hbs`
-        <Menu data-test-menu as |menu|>
+        <Menu as |menu|>
           <menu.Button data-test-menu-button>Trigger</menu.Button>
           <menu.Items />
         </Menu>
@@ -228,12 +213,12 @@ module('Integration | Component | <Menu>', (hooks) => {
 
         assertOpenMenuButton('[data-test-menu-button]');
 
-        assertNoActiveMenuItem('[data-test-menu]');
+        assertNoActiveMenuItem();
       });
 
       test('it should focus the first non disabled menu item when opening with Enter', async () => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item @isDisabled={{true}} as |item|>
@@ -266,7 +251,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('it should focus the first non disabled menu item when opening with Enter (jump over multiple disabled ones)', async () => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item @isDisabled={{true}} as |item|>
@@ -299,7 +284,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('it should have no active menu item upon Enter key press, when there are no non-disabled menu items', async function () {
         await render(hbs`
-        <Menu data-test-menu as |menu|>
+        <Menu as |menu|>
           <menu.Button data-test-menu-button>Trigger</menu.Button>
           <menu.Items data-test-menu-items as |items|>
             <items.Item @isDisabled={{true}} as |item|>
@@ -325,7 +310,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('it should be possible to close the menu with Enter when there is no active menuitem', async function () {
         await render(hbs`
-        <Menu data-test-menu as |menu|>
+        <Menu as |menu|>
           <menu.Button data-test-menu-button>Trigger</menu.Button>
           <menu.Items data-test-menu-items as |items|>
             <items.Item @isDisabled={{true}} as |item|>
@@ -356,7 +341,7 @@ module('Integration | Component | <Menu>', (hooks) => {
         this.set('onClick', (item) => (itemClicked = item.target));
 
         await render(hbs`
-        <Menu data-test-menu as |menu|>
+        <Menu as |menu|>
           <menu.Button data-test-menu-button>Trigger</menu.Button>
           <menu.Items data-test-menu-items as |items|>
             <items.Item as |item|>
@@ -391,7 +376,7 @@ module('Integration | Component | <Menu>', (hooks) => {
         this.set('onClick', (item) => (itemClicked = item.target));
 
         await render(hbs`
-        <Menu data-test-menu as |menu|>
+        <Menu as |menu|>
           <menu.Button data-test-menu-button>Trigger</menu.Button>
           <menu.Items data-test-menu-items as |items|>
             <items.Item as |item|>
@@ -426,9 +411,9 @@ module('Integration | Component | <Menu>', (hooks) => {
     });
 
     module('`Space` key', function () {
-      test('it should be possible to open the menu with Space', async () => {
+      test('it should be possible to open the menu with Space', async (assert) => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -461,10 +446,9 @@ module('Integration | Component | <Menu>', (hooks) => {
           '[data-test-menu-items]'
         );
 
-        assertMenuItems('[data-test-menu]', 3);
-
         const items = getMenuItems();
 
+        assert.equal(items.length, 3, 'There are three visible menu items');
         assertMenuLinkedWithMenuItem(items[0]);
       });
 
@@ -525,7 +509,7 @@ module('Integration | Component | <Menu>', (hooks) => {
     module('`Any` key aka search', function () {
       test('it should be possible to type a full word that has a perfect match', async () => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -552,7 +536,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('it should be possible to type a partial of a word', async () => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -583,7 +567,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('it should be possible to type words with spaces', async () => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -614,7 +598,7 @@ module('Integration | Component | <Menu>', (hooks) => {
 
       test('it should not be possible to search for a disabled item', async () => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -639,9 +623,9 @@ module('Integration | Component | <Menu>', (hooks) => {
     });
 
     module('Mouse interactions', function () {
-      test('it should be possible to open and close a menu on click', async () => {
+      test('it should be possible to open and close a menu on click', async (assert) => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -668,7 +652,9 @@ module('Integration | Component | <Menu>', (hooks) => {
           '[data-test-menu-items]'
         );
 
-        assertMenuItems('[data-test-menu]', 3);
+        const items = getMenuItems();
+
+        assert.equal(items.length, 3, 'There are three visible menu items');
 
         await click('[data-test-menu-button]');
 
@@ -679,7 +665,7 @@ module('Integration | Component | <Menu>', (hooks) => {
       // - it should be a no-op when we click outside of a closed menu
       test('it should be possible to click outside of the menu which should close the menu', async (assert) => {
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             <menu.Button data-test-menu-button>Trigger</menu.Button>
             <menu.Items data-test-menu-items as |items|>
               <items.Item as |item|>
@@ -709,7 +695,7 @@ module('Integration | Component | <Menu>', (hooks) => {
       test('it should not focus button when does not exist', async function (assert) {
         this.set('isShowButton', true);
         await render(hbs`
-          <Menu data-test-menu as |menu|>
+          <Menu as |menu|>
             {{#if this.isShowButton}}
               <menu.Button data-test-menu-button>Trigger</menu.Button>
             {{/if}}


### PR DESCRIPTION
## `Menu` Avoids Rendering a DOM Node

The `Menu` component in the React/Vue implementations does not render a DOM node by default. It _can_, because I believe they want to make sure that all components can use an `as=` property to configure the node that's rendered, but by default it just renders a `Fragment` (which results in nothing in the DOM).

Since Ember doesn't really have a concept of a `Fragment`, I think that not rendering a DOM node at all is closer to the React/Vue implementation than rendering a `div`.

**Note:** This is a breaking change, as any attributes or modifiers placed on this element should be moved to a new parent `div` element

### Before

```hbs
<Menu data-test-menu class="bg-gray" as |menu|>
  ...
</Menu>
```

### After

```hbs
<div data-test-menu class="bg-gray">
  <Menu as |menu|>
    ...
  </Menu>
</div>
```

## `Menu::Items` Focusing on Render

From the Headless UI documentation on the Menu:

> Clicking the `MenuButton` toggles the menu and focuses the `MenuItems` component.

Using the focus trap here is a little unintuitive, because the menu item elements themselves are not focusable. However, this is a useful approach because

* Focus should be locked within the menu anyway, per the accessibility requirements of a menu
* Focus needs to be returned to the previously-focused element when the menu closes, which the `focus-trap` modifier will do for us

The documentation for the `focus-trap` library describes how you should handle a case where the element that focus is trapped within has no focusable children, which is to focus the "wrapper" element itself using `initialFocus`, which is the approach taken here!

Using the `focus-trap` library to return focus to the trigger button should resolve the weirdness around focus returning to the wrong element sometimes. `focus-trap` will also handle the "press-`escape`-to-dismiss-the-menu" behavior for us without needing additional logic for that.

Closes #55
Closes #54 