### PR TITLE
Generate `404` page for Docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Generate Fallback Page
+        run: cp dist/index.html dist/404.html
+
       - name: Upload to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:


### PR DESCRIPTION
Right now, the main page for the docs site works great

https://gavinjoyce.github.io/ember-headlessui/

and navigating by clicking a link _also_ works great, but the URL that it generates maps to a file that doesn't actually exist, resulting in a "not found" experience

https://gavinjoyce.github.io/ember-headlessui/menu/menu-basic

By creating a `404.html` page, GitHub Pages will serve _that_ HTML file instead of their own "not found" page. By using a copy of the Ember app's HTML page, all of our URLs should correctly when hit directly.

(I might merge this PR without extra approvals because the only way to _really_ test if it works is by merging it)