### PR TITLE
Configure Project to use Volta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14.17.2
+      - uses: volta-cli/action@v1
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
+      - uses: volta-cli/action@v1
 
       - uses: actions/cache@v2
         with:

--- a/package.json
+++ b/package.json
@@ -110,5 +110,9 @@
     "*.js": "eslint --fix",
     "*.hbs": "ember-template-lint --fix",
     "*.{json,md,yml}": "prettier --write"
+  },
+  "volta": {
+    "node": "14.17.3",
+    "yarn": "1.22.10"
   }
 }


### PR DESCRIPTION
We currently manage the version of Node to use in CI as part of the workflow definition. This can cause problems; #64 updated the version for one workflow but not for the other, so our documentation deployment workflow is currently broken.

This change configures the `package.json` file for use with Volta, so the project automatically gets the right Node and Yarn versions. This isn't exactly a standard, but is quite common in the Ember community.

We can then use Volta in CI as well to read the `package.json` configuration and get version information from there. Now we have a single source of truth for the right versions to use!

