### PR TITLE
Implement `Transition` Component

### DIFF
--- a/addon/components/transition.hbs
+++ b/addon/components/transition.hbs
@@ -1,0 +1,21 @@
+{{#if this.componentIsMounted}}
+  {{#let (element this.tagName) as |Tag|}}
+    <Tag
+      class={{this.transitionClassNames}}
+      hidden={{this.componentIsHidden}}
+      style={{if this.componentIsHidden 'display: none'}}
+      {{did-insert (set this 'ownDomNode')}}
+      {{did-insert this.trackDomNode}}
+      {{will-destroy this.untrackDomNode}}
+      ...attributes
+    >
+      {{yield
+        (hash
+          Child=(component
+            'transition/child' parent=this show=@show unmount=@unmount
+          )
+        )
+      }}
+    </Tag>
+  {{/let}}
+{{/if}}

--- a/addon/components/transition.js
+++ b/addon/components/transition.js
@@ -1,0 +1,88 @@
+import Component from '@glimmer/component';
+import { getValue } from '@glimmer/tracking/primitives/cache';
+import { invokeHelper } from '@ember/helper';
+import { action } from '@ember/object';
+import { schedule } from '@ember/runloop';
+import { assert } from '@ember/debug';
+import {
+  AppliedClassNamesManager,
+  TransitionVisibilityManager,
+} from '../helpers/transition';
+
+export default class TransitionComponent extends Component {
+  constructor() {
+    super(...arguments);
+
+    let { show } = this.args;
+
+    assert(ARG_SHOW_MISSING_ERROR_MESSAGE, typeof show === 'boolean');
+
+    schedule('afterRender', () => {
+      this.initialRender = false;
+    });
+  }
+
+  get tagName() {
+    return this.args.tagName ?? 'div';
+  }
+
+  get unmount() {
+    return this.args.unmount ?? true;
+  }
+
+  /* === Component Visibility Management === */
+
+  allTransitionDomNodes = new Set();
+
+  transitionVisibilityManager = invokeHelper(
+    this,
+    TransitionVisibilityManager,
+    () => ({
+      positional: [this.allTransitionDomNodes, this.args.show],
+    })
+  );
+
+  get componentIsVisible() {
+    return getValue(this.transitionVisibilityManager);
+  }
+
+  get componentIsMounted() {
+    return this.unmount ? this.componentIsVisible : true;
+  }
+
+  get componentIsHidden() {
+    return this.unmount ? false : !this.componentIsVisible;
+  }
+
+  @action
+  trackDomNode(element) {
+    this.allTransitionDomNodes.add(element);
+  }
+
+  @action
+  untrackDomNode(element) {
+    this.allTransitionDomNodes.delete(element);
+  }
+
+  /* === Transition Class Name Management === */
+
+  initialRender = true;
+
+  /** @type {HTMLElement} */
+  ownDomNode;
+
+  appliedClassNamesManager = invokeHelper(
+    this,
+    AppliedClassNamesManager,
+    () => ({
+      positional: [this, this.args.show],
+    })
+  );
+
+  get transitionClassNames() {
+    return getValue(this.appliedClassNamesManager);
+  }
+}
+
+export const ARG_SHOW_MISSING_ERROR_MESSAGE =
+  'You have to provide a `show` prop to the `Transition` component';

--- a/addon/components/transition/child.hbs
+++ b/addon/components/transition/child.hbs
@@ -1,0 +1,20 @@
+<Transition
+  @show={{@show}}
+  @unmount={{@unmount}}
+  @tagName={{@tagName}}
+  @enter={{@enter}}
+  @enterFrom={{@enterFrom}}
+  @enterTo={{@enterTo}}
+  @leave={{@leave}}
+  @leaveFrom={{@leaveFrom}}
+  @leaveTo={{@leaveTo}}
+  @beforeEnter={{@beforeEnter}}
+  @afterEnter={{@afterEnter}}
+  @beforeLeave={{@beforeLeave}}
+  @afterLeave={{@afterLeave}}
+  {{did-insert @parent.trackDomNode}}
+  {{will-destroy @parent.untrackDomNode}}
+  ...attributes
+>
+  {{yield}}
+</Transition>

--- a/addon/components/transition/child.js
+++ b/addon/components/transition/child.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+export default class TransitionChildComponent extends Component {
+  constructor() {
+    super(...arguments);
+
+    let { parent } = this.args;
+
+    assert(PARENT_MISSING_ERROR_MESSAGE, typeof parent !== 'undefined');
+  }
+}
+
+export const PARENT_MISSING_ERROR_MESSAGE =
+  '<Transition::Child /> is missing a parent <Transition /> component.';

--- a/addon/helpers/transition/applied-class-names.js
+++ b/addon/helpers/transition/applied-class-names.js
@@ -1,0 +1,141 @@
+import Helper from '@ember/component/helper';
+import { dropTask, timeout } from 'ember-concurrency';
+import {
+  ClassNameSet,
+  splitClassNames,
+  waitForTransition,
+} from '../../utils/transition';
+
+export class AppliedClassNamesManager extends Helper {
+  appliedClassNames = new ClassNameSet();
+
+  /**
+   * Tracks the last `this.show` value, so we can determine if we need to initiate a transition as part of `compute`
+   * being executed
+   *
+   * This is because `compute` is sometimes called because an argument changed (and we want to kick off a new
+   * transition) and sometimes it's called to update the produced value during an existing transition (and we *do
+   * not* want to kick off a new transition)
+   */
+  previousShowValue = false;
+
+  /** @type {import('../../components/transition').default} */
+  get transition() {
+    return this.args[0];
+  }
+
+  /**
+   * The `Transition` component's `@show` value
+   *
+   * Represents the desired visibility of the component.
+   *
+   * @type {boolean}
+   */
+  get show() {
+    return this.args[1];
+  }
+
+  get enterClasses() {
+    return splitClassNames(this.transition.args.enter);
+  }
+
+  get enterFromClasses() {
+    return splitClassNames(this.transition.args.enterFrom);
+  }
+
+  get enterToClasses() {
+    return splitClassNames(this.transition.args.enterTo);
+  }
+
+  get enteredClasses() {
+    return splitClassNames(this.transition.args.entered);
+  }
+
+  get leaveClasses() {
+    return splitClassNames(this.transition.args.leave);
+  }
+
+  get leaveFromClasses() {
+    return splitClassNames(this.transition.args.leaveFrom);
+  }
+
+  get leaveToClasses() {
+    return splitClassNames(this.transition.args.leaveTo);
+  }
+
+  @dropTask
+  *setTransitionClassesTask(base, from, to, entered) {
+    this.appliedClassNames.delete(...entered);
+    this.appliedClassNames.add(...base, ...from);
+
+    this.recompute();
+
+    // Wait for the next tick
+    yield timeout(0);
+
+    this.appliedClassNames.delete(...from);
+    this.appliedClassNames.add(...to);
+
+    this.recompute();
+
+    yield waitForTransition(this.transition.ownDomNode);
+
+    this.appliedClassNames.delete(...to, ...base);
+    this.appliedClassNames.add(...entered);
+
+    this.recompute();
+  }
+
+  @dropTask
+  *transitionToShow() {
+    this.transition.args.beforeEnter?.();
+
+    yield this.setTransitionClassesTask.perform(
+      this.enterClasses,
+      this.enterFromClasses,
+      this.enterToClasses,
+      this.enteredClasses
+    );
+
+    this.transition.args.afterEnter?.();
+  }
+
+  @dropTask
+  *transitionToHide() {
+    this.transition.args.beforeLeave?.();
+
+    yield this.setTransitionClassesTask.perform(
+      this.leaveClasses,
+      this.leaveFromClasses,
+      this.leaveToClasses,
+      this.enteredClasses
+    );
+
+    this.transition.args.afterLeave?.();
+  }
+
+  shouldTransition() {
+    return this.show !== this.previousShowValue;
+  }
+
+  compute(positionalArgs) {
+    // Make sure we have a reference to the args
+    this.args = positionalArgs;
+
+    const skip = this.transition.initialRender && !this.transition.args.appear;
+
+    if (!skip && this.shouldTransition()) {
+      if (this.show) {
+        this.transitionToShow.perform();
+      }
+
+      if (!this.show) {
+        this.transitionToHide.perform();
+      }
+    }
+
+    this.previousShowValue = this.show;
+
+    return this.appliedClassNames.toString();
+  }
+}

--- a/addon/helpers/transition/index.js
+++ b/addon/helpers/transition/index.js
@@ -1,0 +1,2 @@
+export { AppliedClassNamesManager } from './applied-class-names';
+export { TransitionVisibilityManager } from './transition-visibility';

--- a/addon/helpers/transition/transition-visibility.js
+++ b/addon/helpers/transition/transition-visibility.js
@@ -1,0 +1,85 @@
+import Helper from '@ember/component/helper';
+import { all, restartableTask, timeout } from 'ember-concurrency';
+import { waitForTransition } from '../../utils/transition';
+
+export class TransitionVisibilityManager extends Helper {
+  /**
+   * Represents whether or not the `Transition` should be visible
+   */
+  value = false;
+
+  /**
+   * Tracks the last `this.show` value, so we can determine if we need to initiate a transition as part of `compute`
+   * being executed
+   *
+   * This is because `compute` is sometimes called because an argument changed (and we want to kick off a new
+   * transition) and sometimes it's called to update the produced value during an existing transition (and we *do
+   * not* want to kick off a new transition)
+   *
+   * @type {undefined|boolean}
+   */
+  previousShowValue = undefined;
+
+  /**
+   * All of the DOM nodes related to a transition
+   *
+   * Includes the parent element plus any children
+   *
+   * @type {Set<HTMLElement>}
+   */
+  get domNodes() {
+    return this.args[0];
+  }
+
+  /**
+   * The `Transition` component's `this.args.show` value
+   *
+   * Represents the desired visibility of the component.
+   *
+   * @type {boolean}
+   */
+  get show() {
+    return this.args[1];
+  }
+
+  isInitialRender() {
+    return typeof this.previousShowValue === 'undefined';
+  }
+
+  shouldTransition() {
+    return this.show !== this.previousShowValue;
+  }
+
+  compute(positionalArgs) {
+    this.args = positionalArgs;
+
+    if (this.isInitialRender()) {
+      this.value = this.show;
+    } else if (this.shouldTransition()) {
+      if (this.show) {
+        this.value = true;
+      } else {
+        this.unmountAfterTransitionTask.perform();
+      }
+    }
+
+    this.previousShowValue = this.show;
+
+    return this.value;
+  }
+
+  @restartableTask
+  *unmountAfterTransitionTask() {
+    // Wait for the next tick, to ensure that the class name string has time to re-build
+    yield timeout(0);
+
+    // Wait for all Transition DOM elements to finish transitioning (parent and children)
+    yield all(
+      Array.from(this.domNodes).map((domNode) => waitForTransition(domNode))
+    );
+
+    this.value = false;
+
+    this.recompute();
+  }
+}

--- a/addon/utils/transition.js
+++ b/addon/utils/transition.js
@@ -1,0 +1,61 @@
+import { TrackedSet } from 'tracked-maps-and-sets';
+import { timeout } from 'ember-concurrency';
+
+/**
+ * Create a promise that resolves after the transition timeout for a node
+ *
+ * Extracted from HeadlessUI here:
+ *
+ * https://github.com/tailwindlabs/headlessui/blob/b961a189d57fa24af2a0bd0a6d73fa44e1d34529/packages/%40headlessui-react/src/components/transitions/utils/transition.ts#L17
+ *
+ * @param {HTMLElement} node
+ * @return {Promise<void>}
+ */
+export async function waitForTransition(node) {
+  // Safari returns a comma separated list of values, so let's sort them and take the highest value.
+  let { transitionDuration, transitionDelay } = getComputedStyle(node);
+  let [durationMs, delaysMs] = [transitionDuration, transitionDelay].map(
+    (value) => {
+      let [resolvedValue = 0] = value
+        .split(',')
+        // Remove falsy we can't work with
+        .filter(Boolean)
+        // Values are returned as `0.3s` or `75ms`
+        .map((v) => (v.includes('ms') ? parseFloat(v) : parseFloat(v) * 1000))
+        .sort((a, z) => z - a);
+
+      return resolvedValue;
+    }
+  );
+
+  if (durationMs !== 0) {
+    await timeout(durationMs + delaysMs);
+  }
+}
+
+export function splitClassNames(classString = '') {
+  return classString
+    .split(' ')
+    .map((part) => part.trim())
+    .filter((part) => part.trim().length > 1);
+}
+
+export class ClassNameSet {
+  data = new TrackedSet();
+
+  add(...values) {
+    for (let value of values) {
+      this.data.add(value);
+    }
+  }
+
+  delete(...values) {
+    for (let value of values) {
+      this.data.delete(value);
+    }
+  }
+
+  toString() {
+    return Array.from(this.data).join(' ');
+  }
+}

--- a/app/components/transition.js
+++ b/app/components/transition.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/components/transition';

--- a/app/components/transition/child.js
+++ b/app/components/transition/child.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/components/transition/child';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,15 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
+    autoImport: {
+      webpack: {
+        node: {
+          // Required to import `testdouble` in tests
+          global: true,
+        },
+      },
+    },
+
     postcssOptions: {
       compile: {
         plugins: [

--- a/package.json
+++ b/package.json
@@ -95,7 +95,9 @@
     "qunit-wait-for": "^2.0.1",
     "release-it": "^14.8.0",
     "release-it-lerna-changelog": "^3.1.0",
-    "tailwindcss": "^2.2.7"
+    "tailwindcss": "^2.2.7",
+    "testdouble": "^3.16.1",
+    "testdouble-qunit": "^3.0.0"
   },
   "resolutions": {
     "@embroider/core": "^0.43.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "ember-concurrency": "^2.1.0",
     "ember-element-helper": "^0.5.5",
     "ember-focus-trap": "^0.7.0",
-    "ember-truth-helpers": "^3.0.0"
+    "ember-truth-helpers": "^3.0.0",
+    "tracked-maps-and-sets": "^3.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/tests/assertions/dom.js
+++ b/tests/assertions/dom.js
@@ -1,0 +1,4 @@
+import * as QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+
+setup(QUnit.assert);

--- a/tests/assertions/testdouble.js
+++ b/tests/assertions/testdouble.js
@@ -1,0 +1,5 @@
+import * as QUnit from 'qunit';
+import td from 'testdouble';
+import installVerifyAssertion from 'testdouble-qunit';
+
+installVerifyAssertion(QUnit, td);

--- a/tests/assertions/wait-for.js
+++ b/tests/assertions/wait-for.js
@@ -1,0 +1,4 @@
+import * as QUnit from 'qunit';
+import { installWaitFor } from 'qunit-wait-for';
+
+installWaitFor(QUnit);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -13,8 +13,9 @@
             <LinkTo @route='menu.menu-with-popper'>Menu with Popper [todo]</LinkTo>
           </li>
           <li>
-            <LinkTo @route='menu.menu-with-transition'>Menu with Transition
-              [todo]</LinkTo>
+            <LinkTo @route='menu.menu-with-transition'>
+              Menu with Transition
+            </LinkTo>
           </li>
           <li>
             <LinkTo @route='menu.menu-with-transition-and-popper'>Menu with

--- a/tests/dummy/app/templates/menu/menu-with-transition.hbs
+++ b/tests/dummy/app/templates/menu/menu-with-transition.hbs
@@ -1,1 +1,78 @@
-menu-with-transition will go here
+<div class='flex justify-center w-screen h-full p-12 bg-gray-50'>
+  <div class='relative inline-block text-left'>
+    <Menu as |menu|>
+      <span class='rounded-md shadow-sm'>
+        <menu.Button
+          class='inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800'
+        >
+          <span>Options</span>
+          <svg
+            class='w-5 h-5 ml-2 -mr-1'
+            viewBox='0 0 20 20'
+            fill='currentColor'
+          >
+            <path
+              fillRule='evenodd'
+              d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z'
+              clipRule='evenodd'
+            ></path>
+          </svg>
+        </menu.Button>
+      </span>
+      <Transition
+        @show={{menu.isOpen}}
+        @appear={{true}}
+        @enter='transition duration-300'
+        @enterFrom='opacity-0'
+        @enterTo='opacity-100'
+        @leave='transition duration-300'
+        @leaveFrom='opacity-100'
+        @leaveTo='opacity-0'
+        class='absolute right-0 mt-2 origin-top-right'
+      >
+        <menu.Items
+          class='w-56 bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none'
+          @isOpen={{true}}
+          as |items|
+        >
+          <div class='px-4 py-3'>
+            <p class='text-sm leading-5'>Signed in as</p>
+            <p
+              class='text-sm font-medium leading-5 text-gray-900 truncate'
+            >tom@example.com</p>
+          </div>
+
+          <div class='py-1'>
+            <items.Item as |item|>
+              <Menus::CustomMenuItem
+                @item={{item}}
+                href='#account-settings'
+              >Account settings</Menus::CustomMenuItem>
+            </items.Item>
+            <items.Item as |item|>
+              <Menus::CustomMenuItem
+                @item={{item}}
+                href='#support'
+              >Support</Menus::CustomMenuItem>
+            </items.Item>
+            <items.Item @isDisabled={{true}} as |item|>
+              <Menus::CustomMenuItem @item={{item}} href='#new-feature'>New
+                feature (soon)</Menus::CustomMenuItem>
+            </items.Item>
+            <items.Item as |item|>
+              <Menus::CustomMenuItem
+                @item={{item}}
+                href='#license'
+              >License</Menus::CustomMenuItem>
+            </items.Item>
+          </div>
+          <div class='py-1'>
+            <items.Item as |item|>
+              <Menus::CustomMenuItem @item={{item}} href='#sign-out'>Sign out</Menus::CustomMenuItem>
+            </items.Item>
+          </div>
+        </menu.Items>
+      </Transition>
+    </Menu>
+  </div>
+</div>

--- a/tests/integration/components/transition-test.js
+++ b/tests/integration/components/transition-test.js
@@ -1,0 +1,695 @@
+import { module, test, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import td from 'testdouble';
+import { ARG_SHOW_MISSING_ERROR_MESSAGE } from 'ember-headlessui/components/transition';
+import { PARENT_MISSING_ERROR_MESSAGE } from 'ember-headlessui/components/transition/child';
+
+module('Integration | Component | transition', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.afterEach(function () {
+    resetOnerror();
+  });
+
+  test('should render without crashing', async function (assert) {
+    await render(hbs`
+      <Transition @show={{true}}>
+        <div class="hello">Children</div>
+      </Transition>
+    `);
+
+    assert.dom('.hello').hasText('Children');
+  });
+
+  test('should be possible to render a Transition without children', async function (assert) {
+    await render(hbs`
+      <Transition data-test-transition @show={{true}} />
+    `);
+
+    assert.dom('[data-test-transition]').exists();
+  });
+
+  test('should yell at us when we forget the required show prop', async function (assert) {
+    assert.expect(1);
+
+    setupOnerror((error) => {
+      assert.equal(
+        error.message,
+        `Assertion Failed: ${ARG_SHOW_MISSING_ERROR_MESSAGE}`,
+        'The `Transition` component must have a `@show` argument'
+      );
+    });
+
+    await render(hbs`
+      <Transition>
+        <div class="hello">Children</div>
+      </Transition>
+    `);
+  });
+
+  module('Setup API', function () {
+    module('shallow', function () {
+      test('should render a div and its children by default', async function (assert) {
+        await render(hbs`
+          <Transition data-test-transition @show={{true}}>
+            Children
+          </Transition>
+        `);
+
+        assert.dom('[data-test-transition]').hasTagName('div');
+        assert.dom('[data-test-transition]').hasText('Children');
+      });
+
+      // Note: this has been translated to the most appropriate analogue: attributes
+      test('should passthrough all the props (that we do not use internally)', async function (assert) {
+        await render(hbs`
+          <Transition data-test-transition id="transition" @show={{true}}>
+            Children
+          </Transition>
+        `);
+
+        assert.dom('[data-test-transition]').hasAttribute('id', 'transition');
+      });
+
+      // should render another component if the `as` prop is used and its children by default
+      test('should render another component if the `tagName` argument is used and its children by default', async function (assert) {
+        await render(hbs`
+          <Transition data-test-transition @tagName="span" @show={{true}}>
+            Children
+          </Transition>
+        `);
+
+        assert.dom('[data-test-transition]').hasTagName('span');
+      });
+
+      // Test is redundant based on the implementation
+      skip(
+        'should passthrough all the props (that we do not use internally) even when using an `as` prop'
+      );
+
+      test('should render nothing when the show prop is false', async function (assert) {
+        await render(hbs`
+          <Transition data-test-transition @show={{false}}>
+            Children
+          </Transition>
+        `);
+
+        assert.dom('[data-test-transition]').doesNotExist();
+      });
+
+      // Test is already covered by previous tests
+      skip('should be possible to change the underlying DOM tag');
+
+      // Test is not relevant in Ember
+      skip('should be possible to use a render prop');
+
+      // Test is not relevant in Ember
+      skip(
+        'should yell at us when we forget to forward the ref when using a render prop'
+      );
+    });
+
+    module('nested', function () {
+      test('should yell at us when we forget to wrap the `<Transition.Child />` in a parent <Transition /> component', async function (assert) {
+        assert.expect(1);
+
+        setupOnerror((error) => {
+          assert.equal(
+            error.message,
+            `Assertion Failed: ${PARENT_MISSING_ERROR_MESSAGE}`,
+            'The `Transition::Child` component must have a parent `Transition` component'
+          );
+        });
+
+        await render(hbs`
+          <Transition::Child @show={{true}}>
+            Oops
+          </Transition::Child>
+        `);
+      });
+
+      test('should be possible to render a Transition.Child without children', async function (assert) {
+        await render(hbs`
+          <Transition @show={{true}} as |t|>
+            <t.Child data-test-transition />
+          </Transition>
+        `);
+
+        assert.dom('[data-test-transition]').exists();
+      });
+
+      // Skipped since `Transition.Root` is not part of the documented API
+      skip(
+        'should be possible to use a Transition.Root and a Transition.Child'
+      );
+
+      test('should be possible to nest transition components', async function (assert) {
+        await render(hbs`
+          <Transition @show={{true}} data-test-transition as |t|>
+            <t.Child data-test-child-1>Sidebar</t.Child>
+            <t.Child data-test-child-2>Content</t.Child>
+          </Transition>
+        `);
+
+        assert.dom('[data-test-transition]').exists();
+        assert.dom('[data-test-child-1]').hasText('Sidebar');
+        assert.dom('[data-test-child-2]').hasText('Content');
+      });
+
+      test('should be possible to change the underlying DOM tag of the Transition.Child components', async function (assert) {
+        await render(hbs`
+          <Transition @show={{true}} as |t|>
+            <t.Child @tagName="aside" data-test-child-1>Sidebar</t.Child>
+            <t.Child @tagName="section" data-test-child-2>Content</t.Child>
+          </Transition>
+        `);
+
+        assert.dom('[data-test-child-1]').hasTagName('aside');
+        assert.dom('[data-test-child-2]').hasTagName('section');
+      });
+
+      // Skipped because functionality is well-covered by other tests
+      skip(
+        'should be possible to change the underlying DOM tag of the Transition component and Transition.Child components'
+      );
+
+      // Skipped because API is not relevant to Ember
+      skip(
+        'should be possible to use render props on the Transition.Child components'
+      );
+
+      // Skipped because API is not relevant to Ember
+      skip(
+        'should be possible to use render props on the Transition and Transition.Child components'
+      );
+
+      // Skipped because API is not relevant to Ember
+      skip(
+        'should yell at us when we forgot to forward the ref on one of the Transition.Child components'
+      );
+
+      // Skipped because API is not relevant to Ember
+      skip(
+        'should yell at us when we forgot to forward a ref on the Transition component'
+      );
+    });
+
+    module('transition classes', function () {
+      test('should be possible to passthrough the transition classes', async function (assert) {
+        await render(hbs`
+          <Transition
+            @show={{true}}
+            @enter="enter"
+            @enterFrom="enter-from"
+            @enterTo="enter-to"
+            @leave="leave"
+            @leaveFrom="leave-from"
+            @leaveTo="leave-to"
+            data-test-transition
+          >
+            Children
+          </Transition>
+        `);
+
+        // Has only the framework-provided classes
+        // NOTE: I thought `ember-view` wasn't relevant anymore?
+        assert
+          .dom('[data-test-transition]')
+          .hasAttribute('class', 'ember-view');
+      });
+
+      test('should be possible to passthrough the transition classes and immediately apply the enter transitions when appear is set to true', async function (assert) {
+        // NOTE: We must *not* await rendering; the transition will have completed by the time it resolves
+        const renderComplete = render(hbs`
+          <Transition
+            @show={{true}}
+            @appear={{true}}
+            @enter="enter"
+            @enterFrom="enter-from"
+            @enterTo="enter-to"
+            @leave="leave"
+            @leaveFrom="leave-from"
+            @leaveTo="leave-to"
+            data-test-transition
+          >
+            Children
+          </Transition>
+        `);
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('enter-from');
+        });
+
+        // Make sure the rendering process is complete before finishing the test
+        await renderComplete;
+      });
+    });
+  });
+
+  module('Transitions', function () {
+    module('shallow transitions', function () {
+      test('should transition in completely (duration defined in milliseconds)', async function (assert) {
+        this.isShown = false;
+        this.showTransition = () => {
+          this.set('isShown', true);
+        };
+
+        await render(hbs`
+          <style>
+            .enter { transition-duration: 50ms }
+            .from { opacity: 0% }
+            .to { opacity: 100% }
+          </style>
+
+          <Transition
+            @show={{this.isShown}}
+            @enter="enter"
+            @enterFrom="from"
+            @enterTo="to"
+            data-test-transition
+          />
+
+          <button {{on 'click' this.showTransition}}>
+            Show the transition: {{this.isShown}}
+          </button>
+        `);
+
+        assert.dom('[data-test-transition]').doesNotExist();
+
+        let showChangeComplete = click('button');
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('from');
+        });
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('to');
+          assert.dom('[data-test-transition]').doesNotHaveClass('from');
+        });
+
+        await showChangeComplete;
+
+        assert.dom('[data-test-transition]').doesNotHaveClass('enter');
+        assert.dom('[data-test-transition]').doesNotHaveClass('to');
+      });
+
+      test('should transition in completely (duration defined in seconds)', async function (assert) {
+        this.isShown = false;
+        this.showTransition = () => {
+          this.set('isShown', true);
+        };
+
+        await render(hbs`
+          <style>
+            .enter { transition-duration: .05s }
+            .from { opacity: 0% }
+            .to { opacity: 100% }
+          </style>
+
+          <Transition
+            @show={{this.isShown}}
+            @enter="enter"
+            @enterFrom="from"
+            @enterTo="to"
+            data-test-transition
+          />
+
+          <button {{on 'click' this.showTransition}}>
+            Show the transition: {{this.isShown}}
+          </button>
+        `);
+
+        assert.dom('[data-test-transition]').doesNotExist();
+
+        let showChangeComplete = click('button');
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('from');
+        });
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('to');
+          assert.dom('[data-test-transition]').doesNotHaveClass('from');
+        });
+
+        await showChangeComplete;
+
+        assert.dom('[data-test-transition]').doesNotHaveClass('enter');
+        assert.dom('[data-test-transition]').doesNotHaveClass('to');
+      });
+
+      test('should transition in completely (duration defined in seconds) in (render strategy = hidden)', async function (assert) {
+        this.isShown = false;
+        this.showTransition = () => {
+          this.set('isShown', true);
+        };
+
+        await render(hbs`
+          <style>
+            .enter { transition-duration: .05s }
+            .from { opacity: 0% }
+            .to { opacity: 100% }
+          </style>
+
+          <Transition
+            @show={{this.isShown}}
+            @unmount={{false}}
+            @enter="enter"
+            @enterFrom="from"
+            @enterTo="to"
+            data-test-transition
+          />
+
+          <button {{on 'click' this.showTransition}}>
+            Show the transition: {{this.isShown}}
+          </button>
+        `);
+
+        assert.dom('[data-test-transition]').exists();
+        assert.dom('[data-test-transition]').isNotVisible();
+
+        let showChangeComplete = click('button');
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('from');
+        });
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('to');
+          assert.dom('[data-test-transition]').doesNotHaveClass('from');
+        });
+
+        await showChangeComplete;
+
+        assert.dom('[data-test-transition]').doesNotHaveClass('enter');
+        assert.dom('[data-test-transition]').doesNotHaveClass('to');
+      });
+
+      // Skipped because this test is already covered above
+      skip('should transition in completely');
+
+      test('it should transition out completely', async function (assert) {
+        this.isShown = true;
+        this.showTransition = () => {
+          this.set('isShown', false);
+        };
+
+        await render(hbs`
+          <style>
+            .leave { transition-duration: .1s; }
+            .from { opacity: 0%; }
+            .to { opacity: 100%; }
+          </style>
+
+          <Transition
+            @show={{this.isShown}}
+            @leave="leave"
+            @leaveFrom="from"
+            @leaveTo="to"
+            data-test-transition
+          />
+
+          <button {{on 'click' this.showTransition}}>
+            Show the transition: {{this.isShown}}
+          </button>
+        `);
+
+        let showChangeComplete = click('button');
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('leave');
+          assert.dom('[data-test-transition]').hasClass('from');
+        });
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('leave');
+          assert.dom('[data-test-transition]').hasClass('to');
+          assert.dom('[data-test-transition]').doesNotHaveClass('from');
+        });
+
+        await showChangeComplete;
+
+        assert.dom('[data-test-transition]').doesNotExist();
+      });
+
+      test('should transition out completely (render strategy = hidden)', async function (assert) {
+        this.isShown = true;
+        this.showTransition = () => {
+          this.set('isShown', false);
+        };
+
+        await render(hbs`
+          <style>
+            .leave { transition-duration: .1s; }
+            .from { opacity: 0%; }
+            .to { opacity: 100%; }
+          </style>
+
+          <Transition
+            @show={{this.isShown}}
+            @unmount={{false}}
+            @leave="leave"
+            @leaveFrom="from"
+            @leaveTo="to"
+            data-test-transition
+          />
+
+          <button {{on 'click' this.showTransition}}>
+            Show the transition: {{this.isShown}}
+          </button>
+        `);
+
+        let showChangeComplete = click('button');
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('leave');
+          assert.dom('[data-test-transition]').hasClass('from');
+        });
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('leave');
+          assert.dom('[data-test-transition]').hasClass('to');
+          assert.dom('[data-test-transition]').doesNotHaveClass('from');
+        });
+
+        await showChangeComplete;
+
+        assert.dom('[data-test-transition]').exists();
+        assert.dom('[data-test-transition]').isNotVisible();
+      });
+
+      // Skipped because this test seems redundant
+      skip('should transition in and out completely');
+
+      // Skipped because this test seems redundant
+      skip(
+        'should transition in and out completely (render strategy = hidden)'
+      );
+    });
+
+    module('nested transitions', function () {
+      test('should not unmount the whole tree when some children are still transitioning', async function (assert) {
+        this.isShown = true;
+        this.showTransition = () => {
+          this.set('isShown', false);
+        };
+
+        await render(hbs`
+          <style>
+            .leave-fast { transition-duration: .1s; }
+            .leave-slow { transition-duration: .2s; }
+            .from { opacity: 100%; }
+            .to { opacity: 0%; }
+          </style>
+          <Transition @show={{this.isShown}} data-test-transition as |t|>
+            <t.Child
+              @leave="leave-fast"
+              @leaveFrom="from"
+              @leaveTo="to"
+              data-test-child-fast
+            >
+              Fast Child
+            </t.Child>
+            <t.Child
+              @leave="leave-slow"
+              @leaveFrom="from"
+              @leaveTo="to"
+              data-test-child-slow
+            >
+              Slow Child
+            </t.Child>
+          </Transition>
+
+          <button {{on 'click' this.showTransition}}>
+            Show the transition: {{this.isShown}}
+          </button>
+        `);
+
+        let showChangeComplete = click('button');
+
+        await assert.waitFor(() => {
+          assert
+            .dom('[data-test-child-fast]')
+            .hasClass('from', 'Fast child has `from` class applied');
+          assert
+            .dom('[data-test-child-slow]')
+            .hasClass('leave-slow', 'Slow child has `from` class applied');
+        });
+
+        await assert.waitFor(() => {
+          assert
+            .dom('[data-test-child-fast]')
+            .hasClass('to', 'Fast child has `to` class applied');
+          assert
+            .dom('[data-test-child-slow]')
+            .hasClass('to', 'Slow child has `to` class applied');
+        });
+
+        await assert.waitFor(() => {
+          assert
+            .dom('[data-test-child-fast]')
+            .doesNotExist('Fast child is hidden after transition duration');
+
+          assert
+            .dom('[data-test-child-slow]')
+            .hasClass('to', 'Slow child still has `to` class applied');
+        });
+
+        await showChangeComplete;
+
+        assert
+          .dom('[data-test-transition]')
+          .doesNotExist('Transition is completely hidden');
+      });
+
+      // Skipped because this seems to require communicating between unrelated `Transition` components
+      // Unsure if/how to implement that
+      // The name of this test is the same as another, but the actual test includes a `Transition` rendered inside a
+      // `Transition::Child`
+      skip(
+        'should not unmount the whole tree when some children are still transitioning'
+      );
+    });
+  });
+
+  module('Events', function () {
+    test('should fire events for all the stages', async function (assert) {
+      this.beforeEnter = td.function();
+      this.afterEnter = td.function();
+      this.beforeLeave = td.function();
+      this.afterLeave = td.function();
+
+      this.isShown = false;
+      this.toggleTransition = () => {
+        this.set('isShown', !this.isShown);
+      };
+
+      await render(hbs`
+        <style>
+          .enter { transition-duration: 50ms }
+          .enter-from { opacity: 0% }
+          .enter-to { opacity: 100% }
+          .leave { transition-duration: 75ms }
+          .leave-from { opacity: 100% }
+          .leave-to { opacity: 0% }
+        </style>
+
+        <Transition
+          @show={{this.isShown}}
+          @enter="enter"
+          @enterFrom="enter-from"
+          @enterTo="enter-to"
+          @leave="leave"
+          @leaveFrom="leave-from"
+          @leaveTo="leave-to"
+          @beforeEnter={{this.beforeEnter}}
+          @afterEnter={{this.afterEnter}}
+          @beforeLeave={{this.beforeLeave}}
+          @afterLeave={{this.afterLeave}}
+          data-test-transition
+        />
+
+        <button {{on 'click' this.toggleTransition}}>
+          Show the transition: {{this.isShown}}
+        </button>
+      `);
+
+      assert.verify(
+        this.beforeEnter(),
+        { times: 0, ignoreExtraArgs: true },
+        'The `beforeEnter` argument has not been called yet'
+      );
+
+      // Events while showing the transition
+      let showChangeComplete = click('button');
+
+      await assert.waitFor(() => {
+        assert.verify(
+          this.beforeEnter(),
+          'The `beforeEnter` argument has been called'
+        );
+      });
+
+      assert.verify(
+        this.afterEnter(),
+        { times: 0, ignoreExtraArgs: true },
+        'The `afterEnter` hook has not been called yet'
+      );
+
+      await assert.waitFor(() => {
+        assert
+          .dom('[data-test-transition]')
+          .hasClass('enter-to', 'The `enter-to` class has been applied');
+      });
+
+      await assert.waitFor(() => {
+        assert.verify(
+          this.afterEnter(),
+          'The `afterEnter` hook has been called'
+        );
+      });
+
+      await showChangeComplete;
+
+      // Events while hiding the transition
+      showChangeComplete = click('button');
+
+      await assert.waitFor(() => {
+        assert.verify(
+          this.beforeLeave(),
+          'The `beforeLeave` argument has been called'
+        );
+      });
+
+      assert.verify(
+        this.afterLeave(),
+        { times: 0, ignoreExtraArgs: true },
+        'The `afterLeave` argument has not been called yet'
+      );
+
+      await assert.waitFor(() => {
+        assert
+          .dom('[data-test-transition]')
+          .hasClass('leave-to', 'The `leave-to` class has been applied');
+      });
+
+      await assert.waitFor(() => {
+        assert.verify(
+          this.afterLeave(),
+          'The `afterLeave` argument has been called'
+        );
+      });
+
+      await showChangeComplete;
+    });
+  });
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,14 +1,12 @@
 import Application from 'dummy/app';
 import config from 'dummy/config/environment';
-import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
-import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
-import { installWaitFor } from 'qunit-wait-for';
+
+import './assertions/dom';
+import './assertions/testdouble';
+import './assertions/wait-for';
 
 setApplication(Application.create(config.APP));
-
-installWaitFor(QUnit);
-setup(QUnit.assert);
 
 start();

--- a/tests/unit/utils/transition-test.js
+++ b/tests/unit/utils/transition-test.js
@@ -1,0 +1,134 @@
+import { module, test } from 'qunit';
+import { rawTimeout as timeout } from 'ember-concurrency';
+import {
+  ClassNameSet,
+  splitClassNames,
+  waitForTransition,
+} from 'ember-headlessui/utils/transition';
+
+module('Unit | Utility | transition', function () {
+  test('ClassNameSet', function (assert) {
+    const set = new ClassNameSet();
+
+    set.add('foo', 'bar', 'baz');
+
+    assert.equal(set.toString(), 'foo bar baz');
+
+    set.delete('foo', 'bar');
+
+    assert.equal(set.toString(), 'baz');
+  });
+
+  module('splitClassNames', function () {
+    test('a class string with spaces separating classes', function (assert) {
+      assert.deepEqual(splitClassNames('foo bar'), ['foo', 'bar']);
+    });
+
+    test('a class string with newlines in it', function (assert) {
+      assert.deepEqual(
+        splitClassNames(`
+        foo
+        bar
+      `),
+        ['foo', 'bar']
+      );
+    });
+
+    test('an empty class string', function (assert) {
+      assert.deepEqual(splitClassNames(), []);
+    });
+  });
+
+  module('waitForTransition', function (hooks) {
+    const TRANSITION = Symbol('Transition');
+    const CONSTANT = Symbol('Constant');
+
+    let element;
+
+    function createElement(duration, delay) {
+      let element = document.createElement('div');
+
+      element.style.transitionDuration = `${duration}ms`;
+
+      if (delay) {
+        element.style.transitionDelay = `${delay}ms`;
+      }
+
+      // Node needs to be in the DOM to use `getComputedStyle` correctly
+      document.body.appendChild(element);
+
+      return element;
+    }
+
+    hooks.afterEach(function () {
+      document.body.removeChild(element);
+    });
+
+    test('it resolves after the transition duration', async function (assert) {
+      element = createElement(2);
+
+      let result = await Promise.race([
+        waitForTransition(element).then(() => TRANSITION),
+        timeout(5).then(() => CONSTANT),
+      ]);
+
+      assert.equal(
+        result,
+        TRANSITION,
+        'The transition resolved before the constant'
+      );
+
+      result = await Promise.race([
+        waitForTransition(element).then(() => TRANSITION),
+        timeout(1).then(() => CONSTANT),
+      ]);
+
+      assert.equal(
+        result,
+        CONSTANT,
+        'The transition resolved after the constant'
+      );
+    });
+
+    test('if there is a delay, resolve after the duration and delay', async function (assert) {
+      element = createElement(2, 2);
+
+      let result = await Promise.race([
+        waitForTransition(element).then(() => TRANSITION),
+        timeout(5).then(() => CONSTANT),
+      ]);
+
+      assert.equal(
+        result,
+        TRANSITION,
+        'The transition resolved before the constant'
+      );
+
+      result = await Promise.race([
+        waitForTransition(element).then(() => TRANSITION),
+        timeout(3).then(() => CONSTANT),
+      ]);
+
+      assert.equal(
+        result,
+        CONSTANT,
+        'The transition resolved after the constant'
+      );
+    });
+
+    test('the delay is ignored if the duration is `0`', async function (assert) {
+      element = createElement(0, 10);
+
+      let result = await Promise.race([
+        waitForTransition(element).then(() => TRANSITION),
+        timeout(1).then(() => CONSTANT),
+      ]);
+
+      assert.equal(
+        result,
+        TRANSITION,
+        'The transition resolved before the constant'
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,7 +1144,7 @@
     ember-cli-babel "^7.10.0"
     ember-modifier-manager-polyfill "^1.1.0"
 
-"@ember/test-helpers@^2.4.0":
+"@ember/test-helpers@^2.3.0", "@ember/test-helpers@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.4.0.tgz#4680783cfad9c474de8a47dd30cc63f4bf8d70ef"
   integrity sha512-tNYc7rsgr6vWfwSD7dkGZzCovrbdPdPwdqs1Q3m38rCGry00PUNadFGM4LL8T/4YmJMghAri3FpVv685ZPVBUA==
@@ -1382,7 +1382,7 @@
     "@handlebars/parser" "^1.1.0"
     simple-html-tokenizer "^0.5.10"
 
-"@glimmer/tracking@^1.0.2", "@glimmer/tracking@^1.0.4":
+"@glimmer/tracking@^1.0.0", "@glimmer/tracking@^1.0.2", "@glimmer/tracking@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.4.tgz#f1bc1412fe5e2236d0f8d502994a8f88af1bbb21"
   integrity sha512-F+oT8I55ba2puSGIzInmVrv/8QA2PcK1VD+GWgFMhF6WC97D+uZX7BFg+a3s/2N4FVBq5KHE+QxZzgazM151Yw==
@@ -5461,7 +5461,7 @@ ember-cli-babel@^6.0.0-beta.4:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6140,6 +6140,14 @@ ember-test-selectors@^5.0.0:
     calculate-cache-key-for-tree "^2.0.0"
     ember-cli-babel "^7.26.4"
     ember-cli-version-checker "^5.1.2"
+
+ember-tracked-storage-polyfill@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-tracked-storage-polyfill/-/ember-tracked-storage-polyfill-1.0.0.tgz#84d307a1e4badc5f84dca681db2cfea9bdee8a77"
+  integrity sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==
+  dependencies:
+    ember-cli-babel "^7.26.3"
+    ember-cli-htmlbars "^5.7.1"
 
 ember-truth-helpers@^3.0.0:
   version "3.0.0"
@@ -11171,7 +11179,7 @@ qunit-wait-for@^2.0.1:
   resolved "https://registry.yarnpkg.com/qunit-wait-for/-/qunit-wait-for-2.0.1.tgz#97d88420e7fa3bc6b1b39a1e39e1ed79eba35e6a"
   integrity sha512-4DGUovQcu/U+s8n8KrkVSNYD1RlzzoXSpPy0pvTfOWhXRVGwE4LccSpGzG+9/0PFMACxJhO+K4F8F35eL4o9iA==
 
-qunit@^2.14.1:
+qunit@^2.14.1, qunit@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.16.0.tgz#b8ed63d512e5d4eaada5afc0c6c9e8b844181ba1"
   integrity sha512-88x9t+rRMbB6IrCIUZvYU4pJy7NiBEv7SX8jD4LZAsIj+dV+kwGnFStOmPNvqa6HM96VZMD8CIIFKH2+3qvluA==
@@ -13022,6 +13030,17 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+tracked-maps-and-sets@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.1.tgz#aa3a71aa7ef4785e784324059b21b83153df445b"
+  integrity sha512-x1IC6C6muJzpeZaQOcollKiLYSazWEtSM5EDCO5PUfbU7RTMa1x7t9SJrwqDxeasvmJCa1QftECsRtI7osOs8w==
+  dependencies:
+    "@ember/test-helpers" "^2.3.0"
+    "@glimmer/tracking" "^1.0.0"
+    ember-cli-babel "^7.26.5"
+    ember-tracked-storage-polyfill "1.0.0"
+    qunit "^2.16.0"
 
 traverse@^0.6.6:
   version "0.6.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9343,12 +9343,12 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@4.17.21, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.6.1:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.6.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -11134,6 +11134,14 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quibble@^0.6.4:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/quibble/-/quibble-0.6.5.tgz#455f606ab3396d04f2384a2ba7f6ce564c4158ed"
+  integrity sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==
+  dependencies:
+    lodash "^4.17.14"
+    resolve "^1.11.1"
+
 quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
@@ -11649,7 +11657,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.11.1, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -11657,7 +11665,7 @@ resolve@^1.1.6, resolve@^1.20.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -12508,6 +12516,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-object-es5@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz#057c3c9a90a127339bb9d1704a290bb7bd0a1ec5"
+  integrity sha1-BXw8mpChJzObudFwSikLt70KHsU=
+  dependencies:
+    is-plain-obj "^1.0.0"
+    is-regexp "^1.0.0"
+
 stringify-object@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
@@ -12759,6 +12775,21 @@ terser@^5.3.0:
     source-map "~0.7.2"
     source-map-support "~0.5.19"
 
+testdouble-qunit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/testdouble-qunit/-/testdouble-qunit-3.0.0.tgz#142e7fe32cbd3d3f442cd8539f236dea63db2fa8"
+  integrity sha512-zd2IKz5eELq4bZPDG0HYE6JTALGibUvrOy9OD05JiiE+4/UEFBDDG7P0tWjJfP5rk2Vm+gK9Do02a/xtvWe+jA==
+
+testdouble@^3.16.1:
+  version "3.16.2"
+  resolved "https://registry.yarnpkg.com/testdouble/-/testdouble-3.16.2.tgz#7ce45d46423fe6cd07926e2371b96ad9e09c1a5b"
+  integrity sha512-oPVoKBXrkP/SaTsF2W7Tpe77whd/jRKbeAVZok1lQKkZ2lFjjFrulpxuHOVF84tMr8PrN8GUUr24Nto/9vs1Lw==
+  dependencies:
+    lodash "^4.17.15"
+    quibble "^0.6.4"
+    stringify-object-es5 "^2.5.0"
+    theredoc "^1.0.0"
+
 testem@^3.2.0:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/testem/-/testem-3.4.2.tgz#0ee3ca4025a9085d47230b0c797c815882d4029e"
@@ -12817,6 +12848,11 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+theredoc@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/theredoc/-/theredoc-1.0.0.tgz#bcace376af6feb1873efbdd0f91ed026570ff062"
+  integrity sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
This is a first attempt as implementing the `Transition` component from Headless UI. The API has been translated as closely as possible to the React/Vue implementations.

# Component API

We have a top-level `Transition` component that takes the same props that the React/Vue implementations do

```hbs
<Transition
  @show={{this.isShown}}
  @enter="transition transition-duration-100"
  @enterFrom="opacity-0"
  @enterTo="opacity-100"
>
  Show me!
</Transition>
```

Based on the `@show` argument, the underlying element (and any children) will be mounted/unmounted. The "secret sauce" of the component is that when the component becomes _not_ shown, we don't immediately unmount the component; we instead apply the `leave` classes and wait for the transition to complete, _then_ unmount.

We also have a "child" component that can be used to coordinate multiple related transitions

```hbs
<Transition @show={{this.isShown}} as |t|>
  <t.Child 
    @enter="transition transition-duration-100"
    @enterFrom="opacity-0"
    @enterTo="opacity-100"
  >
    Show me!
  </t.Child>

  <t.Child 
    @enter="transition transition-duration-200"
    @enterFrom="opacity-0"
    @enterTo="opacity-100"
  >
    Show me!
  </t.Child>
</Transition>
```

The "secret sauce" with coordinating transition/child components is that unmounting will wait for _all_ components in the group -- the parent and all children -- have completed their transition duration.

# Implementation Trade-Offs

Two additional `dependencies` have been added to the addon to implement `Transition`

* `tracked-maps-and-sets`
  * This allows us to use a `Set` to store the list of applied classes, which a nice data structure to use for this. By using the "tracked" version of `Set`, the UI will automatically re-create the transition class string based on changes to the data.
  * I don't think this dependency can really be removed easily
* ~~`ember-could-get-used-to-this`~~
  * Ember doesn't have a concept of a `Resource` as part of the "official" API. A `Resource` allows us to monitor some tracked properties and produce a value that has it's own lifecycle that reacts to those property changes. This was just the thing we needed to react to the `@show` argument changing and, when becoming `false`, delay the unmounting of the component until after the transition completes
  * The `did-update` modifier _sort of_ helps with this, but because the DOM node for `Transition` isn't always rendered, it's not something we can necessarily rely on to react to the changing value. I'm happy to attempt a refactor to remove the use of a `Resource`, but the implementation might end up being more complicated

I was able to refactor out the usage of `ember-could-get-used-to-this` by leveraging the `invokeHelper` API. The implementation is slightly less "clean", as the use of `Helper` as a base class for these stateful value representations is a little more awkward than the `Resource` base class from `ember-could-get-used-to-this`, but I think it's worthwhile in order to avoid bringing in that whole dependency if it's possible to get it working without it.

We could always implement an in-house `HelperManager` for these two `Helper` implementations that would give us an API closer to that of `Resource` _without_ needing to use `ember-could-get-used-to-this`, but that could be a refactor later as it's not really necessary and does result in more code.

I also added a few `devDependencies` to make testing the events that `Transition` emits easier

- `testdouble` allows us to create stub functions and verify that they were called
- `testdouble-qunit` allows us to integrate QUnit and `testdouble` together by adding an assertion to QUnit for verifying that a `testdouble` stub was called

# To-Do

- [ ] Create documentation pages for the `Transition` component
- [ ] Determine how we feel about the additional dependencies
- [x] `waitForTransition` tests might be flakey; it passes consistently when run locally, but has failed at least once in CI

Closes #65 