### PR TITLE
Break out CI testing jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,32 @@ jobs:
         run: yarn install --frozen-lockfile --non-interactive
 
       - name: test
-        run: yarn test
+        run: yarn ember test
+
+  ember-try:
+    runs-on: ubuntu-latest
+    needs: ['lint', 'test']
+    strategy:
+      matrix:
+        ember-try-scenario:
+          [ember--3.25, ember-release, ember-beta, ember-canary]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: test ${{ matrix.ember-try-scenario }}
+        run: yarn ember try:one ${{ matrix.ember-try-scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,29 @@ on:
       - '*'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: lint
+        run: yarn lint
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2
         with:
-          path: '**/node_modules'
-          key: ci-modules-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive


### PR DESCRIPTION
I noticed that the tests seem to be failing on `master`, but it wasn't immediately clear _why_. This is in part because the test command does 6 things all at once:

- lint
- normal `ember test`
- runs Ember Try (4 different scenarios)

While this doesn't _fix_ the failures right now, it _does_ make it a lot more clear what exactly is going wrong by identifying each of those 6 jobs independently. As a bonus, we only bother running Ember Try if the tests pass under normal circumstances!