### PR TITLE
feat(menu): allow item element to be a component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,7 @@ jobs:
     needs: ['lint', 'test']
     strategy:
       matrix:
-        ember-try-scenario:
-          [ember-minimum-supported, ember-release, ember-beta, ember-canary]
+        ember-try-scenario: [ember-minimum-supported, ember-release]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         ember-try-scenario:
-          [ember--3.25, ember-release, ember-beta, ember-canary]
+          [ember-minimum-supported, ember-release, ember-beta, ember-canary]
 
     steps:
       - uses: actions/checkout@v2

--- a/addon/components/menu/item-element.hbs
+++ b/addon/components/menu/item-element.hbs
@@ -1,4 +1,7 @@
-{{#let (element (or @tagName 'a')) as |Tag|}}
+{{#let
+  (if this.tagNameIsComponent @tagName (element (or @tagName 'a')))
+  as |Tag|
+}}
   <Tag
     id={{@guid}}
     role='menuitem'

--- a/addon/components/menu/item-element.js
+++ b/addon/components/menu/item-element.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class MenuItemElement extends Component {
+  get tagNameIsComponent() {
+    return typeof this.args.tagName === 'object';
+  }
+}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,7 +8,7 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember--3.25',
+        name: 'ember-minimum-supported',
         npm: {
           devDependencies: {
             'ember-source': '~3.25.0',

--- a/tests/integration/components/menu-test.js
+++ b/tests/integration/components/menu-test.js
@@ -153,6 +153,28 @@ module('Integration | Component | <Menu>', (hooks) => {
           .hasText('Item A [isActive:false] [isDisabled:false]');
       });
     });
+
+    test('it should be possible to use a custom component as a menu item', async function (assert) {
+      await render(hbs`
+        <Menu as |menu|>
+          <menu.Button data-test-menu-button>Trigger</menu.Button>
+          <menu.Items data-test-menu-items as |items|>
+            {{#let (component 'link-to' route="menu") as |Link|}}
+              <items.Item as |item|>
+                <item.Element @tagName={{Link}} data-test-item-a>
+                  Item A
+                </item.Element>
+              </items.Item>
+            {{/let}}
+          </menu.Items>
+        </Menu>
+      `);
+
+      await triggerKeyEvent('[data-test-menu-button]', 'keydown', Keys.Enter);
+
+      assert.dom('[data-test-item-a]').hasTagName('a');
+      assert.dom('[data-test-item-a]').hasAttribute('href', '/menu');
+    });
   });
 
   module('Keyboard interactions', function () {


### PR DESCRIPTION
This allows for more flexibility when using the `Menu` component, as there's currently not a good way to use a `LinkTo` as an item in the menu.

Another approach could be to make the `item.Element` component into a modifier that can be applied to any kind of element or component, but we would lose the ability to declaratively manage the attributes we need to set on the element. The API allowed in this PR isn't _great_, but it solves the problem of wanting to rendering a link in the menu using a `LinkTo` rather than a native anchor tag.