### PR TITLE
feat(menu): yield actions to open/close menu

### DIFF
--- a/addon/components/menu.hbs
+++ b/addon/components/menu.hbs
@@ -1,6 +1,8 @@
 {{yield
   (hash
     isOpen=this.isOpen
+    open=this.open
+    close=this.close
     Button=(component
       'menu/button'
       buttonGuid=this.buttonGuid

--- a/tests/integration/components/menu-test.js
+++ b/tests/integration/components/menu-test.js
@@ -104,6 +104,29 @@ module('Integration | Component | <Menu>', (hooks) => {
     assertMenuItemsAreCollaped('[data-test-menu-items]');
   });
 
+  test('controlling open/close programmatically', async (assert) => {
+    await render(hbs`
+      <Menu as |menu|>
+        <button data-test-open {{on 'click' menu.open}}>Open</button>
+        <button data-test-close {{on 'click' menu.close}}>Close</button>
+
+        <menu.Items data-test-menu-items as |items|>
+          <items.Item>Item A</items.Item>
+          <items.Item>Item B</items.Item>
+          <items.Item>Item C</items.Item>
+        </menu.Items>
+      </Menu>
+    `);
+
+    await click('[data-test-open]');
+
+    assert.dom('[data-test-menu-items]').exists();
+
+    await click('[data-test-close]');
+
+    assert.dom('[data-test-menu-items]').doesNotExist();
+  });
+
   module('Rendering', () => {
     module('Menu', () => {
       test('Menu yields an object', async (assert) => {


### PR DESCRIPTION
Exposing these actions makes it easier to actually _use_ this component. I ran into a case where I need to close the menu as part of performing another action that isn't part of a menu item, so having the action in the template context is useful to orchestrating that.