### PR TITLE
Fix build error for consuming apps, caused by (set) helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-concurrency": "^2.1.0",
     "ember-element-helper": "^0.5.5",
     "ember-focus-trap": "^0.7.0",
+    "ember-set-helper": "^2.0.1",
     "ember-truth-helpers": "^3.0.0",
     "tracked-maps-and-sets": "^3.0.1"
   },
@@ -73,7 +74,6 @@
     "ember-page-title": "^6.2.1",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
-    "ember-simple-set-helper": "^0.1.2",
     "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.5.1",

--- a/tests/dummy/app/components/dialogs/nested.hbs
+++ b/tests/dummy/app/components/dialogs/nested.hbs
@@ -23,17 +23,17 @@
         <button
           type='button'
           class='inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-          {{on 'click' (set this.value true)}}
+          {{on 'click' (set this 'value' true)}}
         >Open {{inc @level}} a</button>
         <button
           type='button'
           class='inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-          {{on 'click' (set this.value true)}}
+          {{on 'click' (set this 'value' true)}}
         >Open {{inc @level}} b</button>
         <button
           type='button'
           class='inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-          {{on 'click' (set this.value true)}}
+          {{on 'click' (set this 'value' true)}}
         >Open {{inc @level}} c</button>
       </div>
 
@@ -41,7 +41,7 @@
   </div>
   <Dialogs::Nested
     @isOpen={{this.value}}
-    @onClose={{set this.value false}}
+    @onClose={{set this 'value' false}}
     @level={{inc @level}}
   />
 </Dialog>

--- a/tests/dummy/app/templates/dialog/dialog-modal.hbs
+++ b/tests/dummy/app/templates/dialog/dialog-modal.hbs
@@ -2,7 +2,7 @@
   <button
     type='button'
     class='inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-    {{on 'click' (set this.isOpen true)}}
+    {{on 'click' (set this 'isOpen' true)}}
   >
     Open dialog
   </button>
@@ -11,7 +11,7 @@
     class='fixed inset-0 z-10 overflow-y-auto'
     @as='div'
     @isOpen={{this.isOpen}}
-    @onClose={{set this.isOpen false}}
+    @onClose={{set this 'isOpen' false}}
     as |dialog|
   >
     <div

--- a/tests/dummy/app/templates/dialog/dialog-nested.hbs
+++ b/tests/dummy/app/templates/dialog/dialog-nested.hbs
@@ -2,13 +2,13 @@
   <button
     type='button'
     class='inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-    {{on 'click' (set this.isOpen true)}}
+    {{on 'click' (set this 'isOpen' true)}}
   >
     open 1
   </button>
   <Dialogs::Nested
     @isOpen={{this.isOpen}}
-    @onClose={{set this.isOpen false}}
+    @onClose={{set this 'isOpen' false}}
     @level={{1}}
   />
 </div>

--- a/tests/dummy/app/templates/dialog/dialog-slide-over.hbs
+++ b/tests/dummy/app/templates/dialog/dialog-slide-over.hbs
@@ -2,7 +2,7 @@
   <button
     type='button'
     class='inline-flex items-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-    {{on 'click' (set this.isOpen true)}}
+    {{on 'click' (set this 'isOpen' true)}}
   >
     Open dialog
   </button>
@@ -11,7 +11,7 @@
     class='fixed inset-0 overflow-hidden'
     @as='div'
     @isOpen={{this.isOpen}}
-    @onClose={{set this.isOpen false}}
+    @onClose={{set this 'isOpen' false}}
     as |dialog|
   >
     <div class='absolute inset-0 overflow-hidden'>

--- a/tests/dummy/app/templates/switch/switch-basic.hbs
+++ b/tests/dummy/app/templates/switch/switch-basic.hbs
@@ -1,7 +1,7 @@
 <div class='flex items-start justify-center w-screen h-full p-12 bg-gray-50'>
   <Switch
     @isOn={{this.isOn}}
-    @onUpdate={{set this.isOn}}
+    @onUpdate={{set this 'isOn'}}
     class='flex items-center space-x-4'
     as |switch|
   >

--- a/tests/dummy/app/templates/switch/switch-checkbox.hbs
+++ b/tests/dummy/app/templates/switch/switch-checkbox.hbs
@@ -1,7 +1,7 @@
 <div class='flex items-start justify-center w-screen h-full p-12 bg-gray-50'>
   <Switch
     @isOn={{this.isOn}}
-    @onUpdate={{set this.isOn}}
+    @onUpdate={{set this 'isOn'}}
     class='flex items-center space-x-4'
     as |switch|
   >

--- a/tests/integration/components/dialog-test.js
+++ b/tests/integration/components/dialog-test.js
@@ -160,10 +160,10 @@ module('Integration | Component | <Dialog>', function (hooks) {
         this.set('isOpen', false);
 
         await render(hbs`
-          <button id="trigger" type="button" {{on "click" (set this.isOpen true)}}>
+          <button id="trigger" type="button" {{on "click" (set this "isOpen" true)}}>
             Trigger
           </button>
-          <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}}>
+          <Dialog @isOpen={{this.isOpen}} @onClose={{set this "isOpen" false}}>
             <pre>Hello</pre>
             <div tabindex="0"></div>
           </Dialog>
@@ -180,13 +180,13 @@ module('Integration | Component | <Dialog>', function (hooks) {
         this.set('isOpen', false);
 
         await render(hbs`
-          <button id="trigger" type="button" {{on "click" (set this.isOpen true)}}>
+          <button id="trigger" type="button" {{on "click" (set this "isOpen" true)}}>
             Trigger
           </button>
           <Dialog
             class="relative bg-blue-500"
             @isOpen={{this.isOpen}}
-            @onClose={{set this.isOpen false}}
+            @onClose={{set this "isOpen" false}}
           >
             <div tabindex="0"></div>
           </Dialog>
@@ -225,13 +225,13 @@ module('Integration | Component | <Dialog>', function (hooks) {
         this.set('isOpen', false);
 
         await render(hbs`
-          <button id="trigger" type="button" {{on "click" (set this.isOpen true)}}>
+          <button id="trigger" type="button" {{on "click" (set this "isOpen" true)}}>
             Trigger
           </button>
           <Dialog
             class="relative bg-blue-500"
             @isOpen={{this.isOpen}}
-            @onClose={{set this.isOpen false}}
+            @onClose={{set this "isOpen" false}}
             as |d|
           >
             <d.Overlay>Hello</d.Overlay>
@@ -316,11 +316,11 @@ module('Integration | Component | <Dialog>', function (hooks) {
         this.set('isOpen', false);
 
         await render(hbs`
-          <button type="button" {{on "click" (set this.isOpen true)}}>
+          <button type="button" {{on "click" (set this "isOpen" true)}}>
             Trigger
           </button>
 
-          <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}}>
+          <Dialog @isOpen={{this.isOpen}} @onClose={{set this "isOpen" false}}>
             Hello
             <div tabindex="0"></div>
           </Dialog>
@@ -347,11 +347,11 @@ module('Integration | Component | <Dialog>', function (hooks) {
       this.set('isOpen', false);
 
       await render(hbs`
-        <button type="button" {{on "click" (set this.isOpen true)}}>
+        <button type="button" {{on "click" (set this "isOpen" true)}}>
           Trigger
         </button>
 
-        <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}} as |d|>
+        <Dialog @isOpen={{this.isOpen}} @onClose={{set this "isOpen" false}} as |d|>
           <d.Overlay />
           Contents
           <div tabindex="0"></div>
@@ -371,11 +371,11 @@ module('Integration | Component | <Dialog>', function (hooks) {
       this.set('isOpen', false);
 
       await render(hbs`
-        <button type="button" {{on "click" (set this.isOpen true)}}>
+        <button type="button" {{on "click" (set this "isOpen" true)}}>
           Trigger
         </button>
 
-        <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}}>
+        <Dialog @isOpen={{this.isOpen}} @onClose={{set this "isOpen" false}}>
           Contents
           <div tabindex="0"></div>
         </Dialog>
@@ -409,7 +409,7 @@ module('Integration | Component | <Dialog>', function (hooks) {
       await render(hbs`
         {{!-- template-lint-disable no-invalid-interactive  --}}
         <div {{on "click" this.wrapperFn}}>
-          <Dialog @isOpen={{this.isOpen}} @onClose={{set this.isOpen false}} as |d|>
+          <Dialog @isOpen={{this.isOpen}} @onClose={{set this "isOpen" false}} as |d|>
             Contents
             <d.Overlay />
             <div tabindex="0"></div>
@@ -469,7 +469,7 @@ module('Integration | Component | <Dialog>', function (hooks) {
         <div {{on "click" this.wrapperFn}}>
           <Dialog
             @isOpen={{this.isOpen}}
-            @onClose={{set this.isOpen false}}
+            @onClose={{set this "isOpen" false}}
             as |dialog|
           >
             Contents
@@ -514,12 +514,12 @@ module('Integration | Component | <Dialog>', function (hooks) {
         await render(hbs`
           <button
             type="button"
-            {{on 'click' (set this.isOpen true)}}>
+            {{on 'click' (set this "isOpen" true)}}>
             Open 1
           </button>
           <Dialogs::Nested
             @isOpen={{this.isOpen}}
-            @onClose={{set this.isOpen false}}
+            @onClose={{set this "isOpen" false}}
             @level={{1}}
           />
         `);
@@ -767,12 +767,12 @@ module('Integration | Component | <Dialog>', function (hooks) {
       this.set('isOpen', false);
 
       await render(hbs`
-        <button id='trigger' type="button" {{on "click" (set this.isOpen true)}}>
+        <button id='trigger' type="button" {{on "click" (set this "isOpen" true)}}>
           Trigger
         </button>
         <Dialog
           @isOpen={{this.isOpen}}
-          @onClose={{set this.isOpen false}}
+          @onClose={{set this "isOpen" false}}
           @initialFocus='[data-test-focused-button]'
         >
           <input type="text" value="first">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,11 +2775,6 @@ babel-plugin-filter-imports@^4.0.0:
     "@babel/types" "^7.7.2"
     lodash "^4.17.15"
 
-babel-plugin-htmlbars-inline-precompile@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz#c4882ea875d0f5683f0d91c1f72e29a4f14b5606"
-  integrity sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==
-
 babel-plugin-htmlbars-inline-precompile@^4.2.0:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.4.6.tgz#9fd632ad2717226b90bde6940b4148b3a323fddb"
@@ -3729,13 +3724,6 @@ broccoli-node-info@^2.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.2.0.tgz#feb01c13020792f429e01d7f7845dc5b3a7932b3"
   integrity sha512-VabSGRpKIzpmC+r+tJueCE5h8k6vON7EIMMWu6d/FyPdtijwLQ7QvzShEw+m3mHoDzUaj/kiZsDYrS8X2adsBg==
 
-broccoli-output-wrapper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz#f1e0b9b2f259a67fd41a380141c3c20b096828e6"
-  integrity sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==
-  dependencies:
-    heimdalljs-logger "^0.1.10"
-
 broccoli-output-wrapper@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.5.tgz#514b17801c92922a2c2f87fd145df2a25a11bc5f"
@@ -3764,7 +3752,7 @@ broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.3:
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.3.0, broccoli-persistent-filter@^2.3.1:
+broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz#4a052e0e0868b344c3a2977e35a3d497aa9eca72"
   integrity sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==
@@ -3826,19 +3814,6 @@ broccoli-plugin@^2.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
   integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
   dependencies:
-    promise-map-series "^0.2.1"
-    quick-temp "^0.1.3"
-    rimraf "^2.3.4"
-    symlink-or-copy "^1.1.8"
-
-broccoli-plugin@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz#54ba6dd90a42ec3db5624063292610e326b1e542"
-  integrity sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==
-  dependencies:
-    broccoli-node-api "^1.6.0"
-    broccoli-output-wrapper "^2.0.0"
-    fs-merger "^3.0.1"
     promise-map-series "^0.2.1"
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
@@ -5461,7 +5436,7 @@ ember-cli-babel@^6.0.0-beta.4:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -5519,26 +5494,6 @@ ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
-
-ember-cli-htmlbars@^4.2.2:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz#d299e4f7eba6f30dc723ee086906cc550beb252e"
-  integrity sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==
-  dependencies:
-    "@ember/edition-utils" "^1.2.0"
-    babel-plugin-htmlbars-inline-precompile "^3.2.0"
-    broccoli-debug "^0.6.5"
-    broccoli-persistent-filter "^2.3.1"
-    broccoli-plugin "^3.1.0"
-    common-tags "^1.8.0"
-    ember-cli-babel-plugin-helpers "^1.1.0"
-    fs-tree-diff "^2.0.1"
-    hash-for-dep "^1.5.1"
-    heimdalljs-logger "^0.1.10"
-    json-stable-stringify "^1.0.1"
-    semver "^6.3.0"
-    strip-bom "^4.0.0"
-    walk-sync "^2.0.2"
 
 ember-cli-htmlbars@^5.1.0:
   version "5.3.1"
@@ -6035,13 +5990,12 @@ ember-router-generator@^2.0.0:
     "@babel/traverse" "^7.4.5"
     recast "^0.18.1"
 
-ember-simple-set-helper@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-simple-set-helper/-/ember-simple-set-helper-0.1.2.tgz#f0aad11f35df5f0396561ee4552c1790d8ef0930"
-  integrity sha512-Dx66Ki7tqd3R0MpAmE1j1pTI/K5OAcW4XYpz0T23x8KVUWbaZE9zGGUPlxsczf/44ML3kyIvS7rzQ+6DHS7dkw==
+ember-set-helper@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-set-helper/-/ember-set-helper-2.0.1.tgz#e39417531e25089b45ccb905b8c00eda7b3fbbde"
+  integrity sha512-6IIimVGOdehZcncH1ilCY4p7hWBtZqWYMc1Xodr1ATOCuIk6ZO1yztKcUQhlmwl7fE82gL4wHD01T6XP5W59Ng==
   dependencies:
-    ember-cli-babel "^7.17.2"
-    ember-cli-htmlbars "^4.2.2"
+    ember-cli-babel "^7.18.0"
 
 ember-source-channel-url@^1.0.1:
   version "1.2.0"
@@ -7270,7 +7224,7 @@ fs-extra@^9.0.1, fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-merger@^3.0.1, fs-merger@^3.2.1:
+fs-merger@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.2.1.tgz#a225b11ae530426138294b8fbb19e82e3d4e0b3b"
   integrity sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==


### PR DESCRIPTION
My consuming app was throwing the following error, using this addon with the `<Transition>` component:
```
Build Error (PackagerRunner) in node_modules/ember-headlessui/components/transition.hbs

Module Error (from .../node_modules/thread-loader/dist/cjs.js):
Missing helper: set in node_modules/ember-headlessui/components/transition.hbs
```
This PR fixes the issue by moving the set helper module into the package dependencies.

It also upgrades from the deprecated `ember-simple-set-helper` to `ember-set-helper`, and includes the required refactoring.

All tests are passing.