### PR TITLE
🐛 `<Listbox>`: 4 bug fixes for scrolling & focus

### DIFF
--- a/addon/components/listbox.hbs
+++ b/addon/components/listbox.hbs
@@ -18,6 +18,7 @@
       unsetActiveOption=this.unsetActiveOption
       setSelectedOption=this.setSelectedOption
       handleKeyPress=this.handleKeyPress
+      handleKeyDown=this.handleKeyDown
       handleKeyUp=this.handleKeyUp
       openListbox=this.openListbox
       closeListbox=this.closeListbox
@@ -28,8 +29,10 @@
       guid=this.guid
       isOpen=this.isOpen
       registerButtonElement=this.registerButtonElement
+      unregisterButtonElement=this.unregisterButtonElement
       handleButtonClick=this.handleButtonClick
       handleKeyPress=this.handleKeyPress
+      handleKeyDown=this.handleKeyDown
       handleKeyUp=this.handleKeyUp
       isDisabled=this.isDisabled
       openListbox=this.openListbox

--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -313,13 +313,14 @@ export default class ListboxComponent extends Component {
     this.search += key.toLowerCase();
 
     for (let i = 0; i < this.optionElements.length; i++) {
+      let optionElement = this.optionElements[i];
+
       if (
-        !this.optionElements[i].hasAttribute('disabled') &&
-        this.optionElements[i].textContent
-          .trim()
-          .toLowerCase()
-          .startsWith(this.search)
+        !optionElement.hasAttribute('disabled') &&
+        optionElement.textContent.trim().toLowerCase().startsWith(this.search)
       ) {
+        this.scrollIntoView(optionElement);
+
         this.activeOptionIndex = i;
         break;
       }

--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -182,6 +182,8 @@ export default class ListboxComponent extends Component {
       if (this.args.value === optionComponent.args.value) {
         this.selectedOptionIndex = this.activeOptionIndex =
           this.optionElements.length - 1;
+
+        this.scrollIntoView(optionElement);
       }
     }
 
@@ -242,6 +244,13 @@ export default class ListboxComponent extends Component {
     } else {
       this.optionsElement.focus();
     }
+  }
+
+  scrollIntoView(optionElement) {
+    optionElement.parentElement.scroll(
+      0,
+      optionElement.offsetTop - optionElement.parentElement.offsetTop
+    );
   }
 
   @action

--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -8,6 +8,17 @@ const ACTIVATE_NONE = 0;
 const ACTIVATE_FIRST = 1;
 const ACTIVATE_LAST = 2;
 
+const PREVENTED_KEYDOWN_EVENTS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+]);
+
 export default class ListboxComponent extends Component {
   @tracked activeOptionIndex;
   activateBehaviour = ACTIVATE_NONE;
@@ -76,16 +87,7 @@ export default class ListboxComponent extends Component {
 
   @action
   handleKeyDown(event) {
-    if (
-      [
-        'ArrowUp',
-        'ArrowDown',
-        'ArrowLeft',
-        'ArrowRight',
-        'Home',
-        'End',
-      ].indexOf(event.key) > -1
-    ) {
+    if (PREVENTED_KEYDOWN_EVENTS.has(event.key)) {
       event.preventDefault();
     }
   }
@@ -247,6 +249,11 @@ export default class ListboxComponent extends Component {
   }
 
   scrollIntoView(optionElement) {
+    // Cannot use optionElement.scrollIntoView() here because that function
+    // also scrolls the *window* by some amount. Here, we don't want to
+    // jerk the window, we just want to make the the option element visible
+    // inside its container.
+
     optionElement.parentElement.scroll(
       0,
       optionElement.offsetTop - optionElement.parentElement.offsetTop

--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -75,6 +75,22 @@ export default class ListboxComponent extends Component {
   }
 
   @action
+  handleKeyDown(event) {
+    if (
+      [
+        'ArrowUp',
+        'ArrowDown',
+        'ArrowLeft',
+        'ArrowRight',
+        'Home',
+        'End',
+      ].indexOf(event.key) > -1
+    ) {
+      event.preventDefault();
+    }
+  }
+
+  @action
   handleKeyUp(event) {
     if (event.key === 'ArrowDown') {
       if (!this.isOpen) {
@@ -140,6 +156,11 @@ export default class ListboxComponent extends Component {
   @action
   registerButtonElement(buttonElement) {
     this.buttonElement = buttonElement;
+  }
+
+  @action
+  unregisterButtonElement() {
+    this.buttonElement = undefined;
   }
 
   @action

--- a/addon/components/listbox/-button.hbs
+++ b/addon/components/listbox/-button.hbs
@@ -6,11 +6,13 @@
     aria-controls={{@guid}}
     aria-labelledby='{{@guid}}-label {{@guid}}-button'
     {{on 'click' @handleButtonClick}}
+    {{on 'keydown' @handleKeyDown}}
     {{on 'keyup' @handleKeyUp}}
     {{on 'keypress' @handleKeyPress}}
     aria-expanded={{unless @isDisabled (if @isOpen 'true' 'false')}}
     disabled={{@isDisabled}}
     {{did-insert @registerButtonElement}}
+    {{will-destroy @unregisterButtonElement}}
     ...attributes
   >
     {{yield}}

--- a/addon/components/listbox/-button.hbs
+++ b/addon/components/listbox/-button.hbs
@@ -1,6 +1,7 @@
 {{#let (element (or @as 'button')) as |Tag|}}
   <Tag
     role={{if @role @role 'button'}}
+    type={{if @type @type 'button'}}
     id='{{@guid}}-button'
     aria-haspopup='listbox'
     aria-controls={{@guid}}

--- a/addon/components/listbox/-options.hbs
+++ b/addon/components/listbox/-options.hbs
@@ -14,6 +14,7 @@
       {{did-insert @registerOptionsElement}}
       {{will-destroy @unregisterOptionsElement}}
       {{on 'keypress' @handleKeyPress}}
+      {{on 'keydown' @handleKeyDown}}
       {{on 'keyup' @handleKeyUp}}
       {{headlessui-focus-trap
         focusTrapOptions=(hash

--- a/tests/dummy/app/components/listboxes/basic.hbs
+++ b/tests/dummy/app/components/listboxes/basic.hbs
@@ -30,7 +30,7 @@
       </span>
     </listbox.Button>
     <listbox.Options
-      class='z-30 max-w-md absolute w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'
+      class='z-30 max-w-md w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'
       as |options|
     >
       {{#each this.people as |person|}}

--- a/tests/integration/components/listbox-test.js
+++ b/tests/integration/components/listbox-test.js
@@ -3382,4 +3382,33 @@ module('Integration | Component | <Listbox>', function (hooks) {
       assertNoActiveListboxOption();
     });
   });
+
+  test('should be possible to open a listbox without submitting the form', async function (assert) {
+    let callCount = 0;
+
+    this.set('onSubmit', () => {
+      callCount++;
+    });
+
+    await render(hbs`
+      <form {{on 'submit' this.onSubmit}}>
+        <Listbox as |listbox|>
+          <listbox.Button>Trigger</listbox.Button>
+          <listbox.Options as |options|>
+            <options.Option>option</options.Option>
+          </listbox.Options>
+        </Listbox>
+      </form>
+    `);
+    assertListboxButton({
+      state: ListboxState.InvisibleUnmounted,
+    });
+    assertListbox({
+      state: ListboxState.InvisibleUnmounted,
+    });
+    await click(getListboxButton());
+    assertListbox({ state: ListboxState.Visible });
+
+    assert.equal(callCount, 0, 'onSubmit not called');
+  });
 });


### PR DESCRIPTION
# ✨ What Changed & Why

Fixes for the following 4 `<Listbox>` bugs related to scrolling & focus:

1. 🐛 Prevent arrow keys from scrolling the page https://github.com/GavinJoyce/ember-headlessui/pull/81/commits/8f83502c853be77bf03e0d2e3627fd2f9919c0db
2. 🐛 Scroll selected option into view https://github.com/GavinJoyce/ember-headlessui/pull/81/commits/ebccd5813611dd5ccc0ab6e1a200c0c0cb15b0fa
3. 🐛 Scroll searched option into view https://github.com/GavinJoyce/ember-headlessui/pull/81/commits/855f9e668ccd4a0605dd09c51b06a29d17a84452
4. 🐛 it should be possible to open a listbox without submitting the form https://github.com/GavinJoyce/ember-headlessui/pull/81/commits/d14513ad4c709ed75541667a217006bb00007bbe

