### PR TITLE
🐛  <Transition> pass appear param to child transition

### DIFF
--- a/addon/components/transition/child.hbs
+++ b/addon/components/transition/child.hbs
@@ -1,4 +1,5 @@
 <Transition
+  @appear={{@appear}}
   @show={{@show}}
   @unmount={{@unmount}}
   @tagName={{@tagName}}

--- a/tests/integration/components/transition-test.js
+++ b/tests/integration/components/transition-test.js
@@ -246,6 +246,32 @@ module('Integration | Component | transition', function (hooks) {
         // Make sure the rendering process is complete before finishing the test
         await renderComplete;
       });
+
+      test('should be possible to passthrough the enter classes and immediately apply the enter transitions when appear is set to true on Child component', async function (assert) {
+        // NOTE: We must *not* await rendering; the transition will have completed by the time it resolves
+        const renderComplete = render(hbs`
+          <Transition
+            @show={{true}}
+          as |t|>
+            <t.Child
+              @appear={{true}}
+              @enter="enter"
+              @enterFrom="enter-from"
+              data-test-transition
+            >
+              Children
+            </t.Child>
+          </Transition>
+        `);
+
+        await assert.waitFor(() => {
+          assert.dom('[data-test-transition]').hasClass('enter');
+          assert.dom('[data-test-transition]').hasClass('enter-from');
+        });
+
+        // Make sure the rendering process is complete before finishing the test
+        await renderComplete;
+      });
     });
   });
 


### PR DESCRIPTION
### What changed and why.
I wanted to update transition documentation for dialogs, and I find out that even though enter classes for child transition are passed correctly, transition is not fired when `appear` parameter is true (initial transition). 

Test checks that initial render is executed when flag is passed. I assume that API for `child` is the same as `<transtion>`, and `appear` was overlooked rather than omitted intentionally.

@alexlafroscia as transition is implemented by you, would be wonderful if you check that fix is fine