### PR TITLE
create a `tag-name-is-component` helper

### DIFF
--- a/addon/components/menu/item-element.hbs
+++ b/addon/components/menu/item-element.hbs
@@ -1,5 +1,5 @@
 {{#let
-  (if this.tagNameIsComponent @tagName (element (or @tagName 'a')))
+  (if (tag-name-is-component @tagName) @tagName (element (or @tagName 'a')))
   as |Tag|
 }}
   <Tag

--- a/addon/components/menu/item-element.js
+++ b/addon/components/menu/item-element.js
@@ -1,7 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class MenuItemElement extends Component {
-  get tagNameIsComponent() {
-    return typeof this.args.tagName === 'object';
-  }
-}

--- a/addon/helpers/tag-name-is-component.js
+++ b/addon/helpers/tag-name-is-component.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+function tagNameIsComponent([as]) {
+  return typeof as === 'object';
+}
+
+export default helper(tagNameIsComponent);

--- a/app/helpers/tag-name-is-component.js
+++ b/app/helpers/tag-name-is-component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/helpers/tag-name-is-component';


### PR DESCRIPTION
part of https://github.com/GavinJoyce/ember-headlessui/issues/77#issuecomment-932958600

This removes the need for the `Menu::ItemElement` component to have a backing class.

An existing test is covering this: https://github.com/GavinJoyce/ember-headlessui/commit/83796b38b6829e62c631c94e56c0542a6828156d#diff-2f1746c8a31c717bfe0069265e1afc57117088ae1761e4a498ecaa6ebc325897R157