### PR TITLE
➖ Remove ember focus trap addon

### DIFF
--- a/addon/components/dialog.hbs
+++ b/addon/components/dialog.hbs
@@ -6,7 +6,9 @@
         role='dialog'
         aria-modal='true'
         ...attributes
-        {{focus-trap focusTrapOptions=(hash initialFocus=@initialFocus)}}
+        {{headlessui-focus-trap
+          focusTrapOptions=(hash initialFocus=@initialFocus)
+        }}
         {{click-outside this.onClose event='mouseup'}}
         {{this.handleEscapeKey @isOpen this.onClose}}
         {{did-insert (fn this.dialogStackProvider.push this)}}

--- a/addon/components/listbox/-options.hbs
+++ b/addon/components/listbox/-options.hbs
@@ -15,8 +15,7 @@
       {{will-destroy @unregisterOptionsElement}}
       {{on 'keypress' @handleKeyPress}}
       {{on 'keyup' @handleKeyUp}}
-      {{focus-trap
-        shouldSelfFocus=true
+      {{headlessui-focus-trap
         focusTrapOptions=(hash
           allowOutsideClick=@handleClickOutside fallbackFocus=(concat '#' @guid)
         )

--- a/addon/components/menu/items.hbs
+++ b/addon/components/menu/items.hbs
@@ -7,7 +7,7 @@
     role='menu'
     ...attributes
     {{on 'keydown' this.onKeydown}}
-    {{focus-trap
+    {{headlessui-focus-trap
       focusTrapOptions=(hash
         allowOutsideClick=this.allowClickOutsideFocusTrap
         clickOutsideDeactivates=this.clickOutsideFocusTrapDeactivates

--- a/addon/modifiers/headlessui-focus-trap.js
+++ b/addon/modifiers/headlessui-focus-trap.js
@@ -1,0 +1,15 @@
+import { modifier } from 'ember-modifier';
+import { createFocusTrap } from 'focus-trap';
+
+export default modifier(function headlessuiFocusTrap(
+  element,
+  params,
+  { focusTrapOptions } = {}
+) {
+  let trap = createFocusTrap(element, focusTrapOptions);
+  trap.activate();
+
+  return () => {
+    trap.deactivate();
+  };
+});

--- a/app/modifiers/headlessui-focus-trap.js
+++ b/app/modifiers/headlessui-focus-trap.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-headlessui/modifiers/headlessui-focus-trap';

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "ember-click-outside-modifier": "^2.0.0",
     "ember-concurrency": "^2.1.0",
     "ember-element-helper": "^0.5.5",
-    "ember-focus-trap": "^0.7.0",
     "ember-set-helper": "^2.0.1",
     "ember-truth-helpers": "^3.0.0",
-    "tracked-maps-and-sets": "^3.0.1"
+    "focus-trap": "^6.7.1",
+    "tracked-maps-and-sets": "^3.0.1",
+    "ember-auto-import": "^1.11.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -57,7 +58,6 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "dotenv-cli": "^4.0.0",
-    "ember-auto-import": "^1.11.2",
     "ember-cli": "~3.27.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-deprecation-workflow": "^2.0.0",
@@ -70,6 +70,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-modifier": "^2.1.2",
     "ember-on-helper": "^0.1.0",
     "ember-page-title": "^6.2.1",
     "ember-qunit": "^5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,7 +1203,7 @@
     walk-sync "^3.0.0"
     wrap-legacy-hbs-plugin-if-needed "^1.0.1"
 
-"@embroider/macros@0.43.5", "@embroider/macros@^0.41.0", "@embroider/macros@^0.43.5":
+"@embroider/macros@0.43.5", "@embroider/macros@^0.43.5":
   version "0.43.5"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.43.5.tgz#f846bb883482436611a58a3512c687d4f9fddfad"
   integrity sha512-WmLa0T3dyG2XyN5Gr7k1RINDirFzAzh6CRvykRMcuahq1rCrav8ADrWgQzKpPWxdR6DgQCuoyimopJhLbYOpgQ==
@@ -5884,17 +5884,6 @@ ember-export-application-global@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
-ember-focus-trap@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-0.7.0.tgz#8c3fa66a0d393dad2994db82e2fa227103875fc0"
-  integrity sha512-WHOD8jTcCzsRb0cU8J5SKObrxbdD8rPSWrSUjZ2QYu9dVbaXg6/hZxcN5JrmPY1ArnsRaLMPdOUALYeZTP29og==
-  dependencies:
-    "@embroider/macros" "^0.41.0"
-    ember-auto-import "^1.11.2"
-    ember-cli-babel "^7.26.3"
-    ember-modifier-manager-polyfill "^1.2.0"
-    focus-trap "^6.4.0"
-
 ember-load-initializers@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz#8a47a656c1f64f9b10cecdb4e22a9d52ad9c7efa"
@@ -7090,12 +7079,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap@^6.4.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.5.0.tgz#d99fdf5f3da07c08e7f5b9cad33746db2b215f97"
-  integrity sha512-mezVantxaWNMrcJcrdw/bDfW3rVkl0xcdHKiHbNZzJ2R+KfcW9S6j48wFUAu7C52GFeQDGEWgDEIAvk9PxFvZw==
+focus-trap@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.1.tgz#d474f86dbaf3c7fbf0d53cf0b12295f4f4068d10"
+  integrity sha512-a6czHbT9twVpy2RpkWQA9vIgwQgB9Nx1PIxNNUxQT4nugG/3QibwxO+tWTh9i+zSY2SFiX4pnYhTaFaQF/6ZAg==
   dependencies:
-    tabbable "^5.2.0"
+    tabbable "^5.2.1"
 
 follow-redirects@^1.0.0:
   version "1.14.1"
@@ -12616,10 +12605,10 @@ sync-disk-cache@^2.0.0:
     rimraf "^3.0.0"
     username-sync "^1.0.2"
 
-tabbable@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
-  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
+tabbable@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
+  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
 
 table@^6.0.9:
   version "6.7.1"


### PR DESCRIPTION
We still have some skipped / todo tests in dialog, listbox, menu(?) which are related to focused element after close component or click outside. 
[dialog test](https://github.com/GavinJoyce/ember-headlessui/blob/master/tests/integration/components/dialog-test.js#L411)
[listbox](https://github.com/GavinJoyce/ember-headlessui/blob/master/tests/integration/components/listbox-test.js#L2985)

To sort them out, I added some useful functionality to `focus-trap` package: [link](https://github.com/focus-trap/focus-trap/pull/497)
Last step would be to update `ember-focus-trap` with new version of `focus-trap`. When I tried to do it locally and fix remaining tests, I figured out that `ember-focus-trap` adds some extra functionality to it. Currently, we don't use any of them + one of the functionality causes a bug, which I described [here](https://github.com/josemarluedke/ember-focus-trap/issues/40). 
TL TR: `ember-focus-trap` replicates behavior which is already implemented in `focus-trap`

With this issue I think we are not able to fix those remaining tests. This PR removes `ember-focus-trap` in favor of own bare minimum implementation. Tests are still passing, so I assume that I didn't change any behavior.