### PR TITLE
✨ <Dialog/> Set return focus on clicked element

### DIFF
--- a/addon/components/dialog.hbs
+++ b/addon/components/dialog.hbs
@@ -7,9 +7,12 @@
         aria-modal='true'
         ...attributes
         {{headlessui-focus-trap
-          focusTrapOptions=(hash initialFocus=@initialFocus)
+          focusTrapOptions=(hash
+            initialFocus=@initialFocus
+            allowOutsideClick=this.allowOutsideClick
+            setReturnFocus=this.setReturnFocus
+          )
         }}
-        {{click-outside this.onClose event='mouseup'}}
         {{this.handleEscapeKey @isOpen this.onClose}}
         {{did-insert (fn this.dialogStackProvider.push this)}}
         {{will-destroy (fn this.dialogStackProvider.remove this)}}
@@ -17,13 +20,13 @@
         {{yield
           (hash
             isOpen=@isOpen
-            onClose=@onClose
+            onClose=this.onClose
             Overlay=(component
               'dialog/-overlay'
               guid=this.overlayGuid
               dialogGuid=this.guid
               isOpen=@isOpen
-              onClose=@onClose
+              onClose=this.onClose
             )
             Title=(component
               'dialog/-title'

--- a/addon/components/dialog.ts
+++ b/addon/components/dialog.ts
@@ -30,6 +30,7 @@ export default class DialogComponent extends Component<Args> {
 
   guid = `${guidFor(this)}-headlessui-dialog`;
   $portalRoot = getPortalRoot();
+  outsideClickedElement: HTMLElement | null = null;
 
   handleEscapeKey = modifier(
     (_element, [isOpen, onClose]: [boolean, () => void]) => {
@@ -101,6 +102,21 @@ export default class DialogComponent extends Component<Args> {
 
   get descriptionGuid() {
     return `${this.guid}-description`;
+  }
+
+  @action
+  setReturnFocus(trigger: HTMLElement) {
+    return this.outsideClickedElement ? this.outsideClickedElement : trigger;
+  }
+
+  @action
+  allowOutsideClick(e: MouseEvent) {
+    let target = e.target as HTMLElement;
+    if (target && target.tagName !== 'BODY') {
+      this.outsideClickedElement = target;
+    }
+    this.onClose();
+    return true
   }
 
   @action

--- a/addon/components/dialog.ts
+++ b/addon/components/dialog.ts
@@ -112,11 +112,14 @@ export default class DialogComponent extends Component<Args> {
   @action
   allowOutsideClick(e: MouseEvent) {
     let target = e.target as HTMLElement;
+
     if (target && target.tagName !== 'BODY') {
       this.outsideClickedElement = target;
     }
+
     this.onClose();
-    return true
+
+    return true;
   }
 
   @action

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-typescript": "^4.2.1",
-    "ember-click-outside-modifier": "^2.0.0",
     "ember-concurrency": "^2.1.2",
     "ember-element-helper": "^0.5.5",
     "ember-set-helper": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6218,15 +6218,6 @@ ember-cli@~3.27.0:
     workerpool "^6.0.3"
     yam "^1.0.0"
 
-ember-click-outside-modifier@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-click-outside-modifier/-/ember-click-outside-modifier-2.0.0.tgz#8417a44db8bafef87e08f3614ad809ad1a6020e1"
-  integrity sha512-5FkTsSiSoDh4wL0mqJ2niOZH3ykevcRdLxA2pgZ9JqCMpvMqAQon5valAA4mvW6HiP9lnwm+GR/WijtL0dsdcg==
-  dependencies:
-    ember-cli-babel "^7.26.6"
-    ember-cli-htmlbars "^5.7.1"
-    ember-modifier "^2.1.2"
-
 ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"


### PR DESCRIPTION
### **What changed and why**

PR adds `setReturnFocus` option from `focus-trap` where we can explicitly set which element should be focus after deactivation. Default behavior is to return focus to the element which opened the dialog (trigger button). 
When there is no overlay, and the user clicks outside the dialog, focus will be set to the element which is clicked by the user (see test).
By the way of implementing it, I figure out that `focus-trap` also uses similar pattern to detect `outside-click`, so far we used dedicated modifier (`outside-click-modifier`) as we use it only here I think we can use `focus-trap` and safely remove `outside-click-modifier` from dependency list.