### PR TITLE
fix(dialog): lock scroll when the dialog is open

### DIFF
--- a/addon/components/dialog.hbs
+++ b/addon/components/dialog.hbs
@@ -14,6 +14,7 @@
           )
         }}
         {{this.handleEscapeKey @isOpen this.onClose}}
+        {{this.lockWindowScroll}}
         {{did-insert (fn this.dialogStackProvider.push this)}}
         {{will-destroy (fn this.dialogStackProvider.remove this)}}
       >

--- a/addon/services/dialog-stack-provider.ts
+++ b/addon/services/dialog-stack-provider.ts
@@ -8,6 +8,10 @@ interface WithGuid {
 export default class DialogStackProvider extends Service {
   stack: string[] = [];
 
+  get dialogIsOpen() {
+    return this.stack.length !== 0;
+  }
+
   @action
   hasOpenChild(dialog: WithGuid) {
     return this.stack[this.stack.length - 1] !== dialog.guid;

--- a/tests/integration/components/dialog-test.js
+++ b/tests/integration/components/dialog-test.js
@@ -9,6 +9,7 @@ import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
 import userEvent from '@testing-library/user-event';
+import { getPortalRoot } from 'ember-headlessui/components/dialog';
 import { Keys } from 'ember-headlessui/utils/keyboard';
 
 import {
@@ -233,7 +234,50 @@ module('Integration | Component | <Dialog>', function (hooks) {
         async function () {}
       );
 
-      todo('it should add a scroll lock to the html tag', async function () {});
+      test('it should add a scroll lock to the html tag', async function (assert) {
+        const portalRoot = getPortalRoot();
+        this.set('isOpen', false);
+
+        await render(hbs`
+          <button id="trigger" type="button" {{on "click" (set this "isOpen" true)}}>
+            Trigger
+          </button>
+          <Dialog
+            class="relative bg-blue-500"
+            @isOpen={{this.isOpen}}
+            @onClose={{set this "isOpen" false}}
+            as |d|
+          >
+            <d.Overlay data-test-overlay>Hello</d.Overlay>
+            <div tabindex="0"></div>
+          </Dialog>
+        `);
+
+        assert
+          .dom(portalRoot)
+          .doesNotHaveStyle(
+            { overflow: 'hidden' },
+            'The page is not initially "locked"'
+          );
+
+        await click(document.getElementById('trigger'));
+
+        assert
+          .dom(portalRoot)
+          .hasStyle(
+            { overflow: 'hidden' },
+            'The page becomes "locked" when the dialog is open'
+          );
+
+        await click('[data-test-overlay]');
+
+        assert
+          .dom(portalRoot)
+          .doesNotHaveStyle(
+            { overflow: 'hidden' },
+            'The page is "unlocked" when the dialog closes'
+          );
+      });
     });
 
     module('Dialog.Overlay', function () {


### PR DESCRIPTION
While working with the `Dialog` component, @JessWallin and I noticed that we're not locking the scroll of the page behind the `Dialog` when it's open. This is something we should be doing:

- The documentation for the "real" HeadlessUI [mentions it](https://headlessui.dev/react/dialog#other)
- The code for how the React implementation does this is [here](https://github.com/tailwindlabs/headlessui/blob/e9e6aded545c329585d8cf7452ad9fe400a5406b/packages/%40headlessui-react/src/components/dialog/dialog.tsx#L229-L246)

This PR adds a modifier to `Dialog` that follows the exact same approach as the React version to locking the page scroll.

The _one_ difference is that the React implementation applies the styles to `document.documentElement`, which is the `html` element, while we decided to use `$portalRoot` (which is likely `document.body` instead). This seems to work just as well, and we looked around online for other instances of scroll-locking; many of them style `body` rather than `html`. Using `$portalRoot` means that only the test preview window is locked, which seemed like a helpful way for us to avoid messing with the QUnit UI during tests that make use of `Dialog`!

PR co-authored by @JessWallin