### PR TITLE
Move `ember-test-selectors` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-concurrency": "^2.1.2",
     "ember-element-helper": "^0.5.5",
     "ember-set-helper": "^2.0.1",
+    "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
     "focus-trap": "^6.7.1",
     "tracked-maps-and-sets": "^3.0.1"
@@ -105,7 +106,6 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.5.1",
     "ember-template-lint-plugin-prettier": "^2.0.1",
-    "ember-test-selectors": "^6.0.0",
     "ember-try": "^2.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",


### PR DESCRIPTION
This makes sure that `data-test` selectors are also stripped when the consuming app doesn't have `ember-test-selectors` installed itself.