### PR TITLE
Fix `it should add a scroll lock to the html tag` test

### DIFF
--- a/tests/integration/components/dialog-test.js
+++ b/tests/integration/components/dialog-test.js
@@ -248,7 +248,7 @@ module('Integration | Component | <Dialog>', function (hooks) {
             @onClose={{set this "isOpen" false}}
             as |d|
           >
-            <d.Overlay data-test-overlay>Hello</d.Overlay>
+            <d.Overlay>Hello</d.Overlay>
             <div tabindex="0"></div>
           </Dialog>
         `);
@@ -269,7 +269,7 @@ module('Integration | Component | <Dialog>', function (hooks) {
             'The page becomes "locked" when the dialog is open'
           );
 
-        await click('[data-test-overlay]');
+        await click(getDialogOverlay());
 
         assert
           .dom(portalRoot)


### PR DESCRIPTION
I just checked out the project locally and this test was failing consistently for me. I'm a bit confused as to why, because it seems this doesn't happen during CI? It seems the issue is that the dialog overlay is rendered outside of the testing container which is used as the root when querying elements. Using the `getDialogOverlay` helper fixes this as it uses the `document` as the root to get the dialog overlay element. The same is done [here](https://github.com/GavinJoyce/ember-headlessui/blob/master/tests/integration/components/dialog-test.js#L449) and [here](https://github.com/GavinJoyce/ember-headlessui/blob/master/tests/integration/components/dialog-test.js#L530).