### PR TITLE
✨ <Menu /> support static option for Items

### DIFF
--- a/addon/components/menu/items.hbs
+++ b/addon/components/menu/items.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-down-event-binding }}
-{{#if @isOpen}}
+{{#if (or @isOpen @static)}}
   <div
     id={{@itemsGuid}}
     aria-labelledby={{@buttonGuid}}

--- a/tests/integration/components/menu-test.js
+++ b/tests/integration/components/menu-test.js
@@ -219,6 +219,21 @@ module('Integration | Component | <Menu>', (hooks) => {
       assert.dom('[data-test-item-a]').hasTagName('a');
       assert.dom('[data-test-item-a]').hasAttribute('href', '/menu');
     });
+
+    test('should be possible to always render the Menu.Items if we provide it a `static` prop', async function (assert) {
+      await render(hbs`
+        <Menu as |menu|>
+          <menu.Button>Trigger</menu.Button>
+          <menu.Items data-test-menu-items @static={{true}} as |items|>
+              <items.Item>Item A</items.Item>
+              <items.Item>Item B</items.Item>
+              <items.Item>Item C</items.Item>
+          </menu.Items>
+        </Menu>
+      `);
+
+      assert.dom('[data-test-menu-items]').isVisible();
+    });
   });
 
   module('Keyboard interactions', function () {


### PR DESCRIPTION
This PR add support for the `static` option in the  MenuItems component which is used to determine whether the element should ignore the internally managed open/closed state.

Prop: `static`
Type: `Boolean`
Default: `false`