### PR TITLE
Add Fallback Focus to Dialog

### DIFF
--- a/addon/components/dialog.hbs
+++ b/addon/components/dialog.hbs
@@ -5,12 +5,14 @@
         id={{this.guid}}
         role='dialog'
         aria-modal='true'
+        tabindex='-1'
         ...attributes
         {{headlessui-focus-trap
           focusTrapOptions=(hash
             initialFocus=@initialFocus
             allowOutsideClick=this.allowOutsideClick
             setReturnFocus=this.setReturnFocus
+            fallbackFocus=this.dialogElementSelector
           )
         }}
         {{this.handleEscapeKey @isOpen this.onClose}}

--- a/addon/components/dialog.ts
+++ b/addon/components/dialog.ts
@@ -122,6 +122,10 @@ export default class DialogComponent extends Component<Args> {
     return this.args.as || this.DEFAULT_TAG_NAME;
   }
 
+  get dialogElementSelector() {
+    return `#${this.guid}`;
+  }
+
   get overlayGuid() {
     return `${this.guid}-overlay`;
   }

--- a/tests/integration/components/dialog-test.js
+++ b/tests/integration/components/dialog-test.js
@@ -904,5 +904,28 @@ module('Integration | Component | <Dialog>', function (hooks) {
         assertActiveElement(getByText('focused'));
       });
     });
+
+    test('it should fallback to focus the dialog if there are no focusable elements', async function (assert) {
+      this.set('isOpen', false);
+
+      await render(hbs`
+        <button id='trigger' type="button" {{on "click" (set this "isOpen" true)}}>
+          Trigger
+        </button>
+        <Dialog
+          @isOpen={{this.isOpen}}
+          @onClose={{set this "isOpen" false}}
+        >
+          <h2>focused the whole dialog</h2>
+        </Dialog>
+      `);
+
+      await click('#trigger');
+
+      await assert.waitFor(() => {
+        // focus is on the actual dialog as a fallback
+        return assertActiveElement(getDialog());
+      });
+    });
   });
 });


### PR DESCRIPTION
Hey folks 👋 

We were having a few issues with Dialog sometimes failing because of the lack of a focusable element. It was failing with the following message from focus-trap: 

```
Your focus-trap must have at least one container with at least one tabbable node in it at all times
```

I looked into the other places in the codebase where focus-trap was being used and it does look like we're making use of the fallback focus functionality of `focus-trap` in the `Menu::Items` component: https://github.com/mansona/ember-headlessui/blob/dialog-fallback-focus/addon/components/menu/items.hbs#L15

I just lifted essentially the same implementation used for `Menu::Items` and applied it to Dialog 👍 I also wrote a test that verifies that the functionality actually works now 🎉 

Let me know if you have any questions. 
