### PR TITLE
✨ <Listbox> Add an argument to prevent automatically scrolling options into view

### DIFF
--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -254,7 +254,9 @@ export default class ListboxComponent extends Component {
     // jerk the window, we just want to make the the option element visible
     // inside its container.
 
-    optionElement.parentElement.scroll(
+    if (this.args.preventScrollToOption) return;
+
+    optionElement.parentElement?.scroll(
       0,
       optionElement.offsetTop - optionElement.parentElement.offsetTop
     );

--- a/tests/integration/components/listbox-test.js
+++ b/tests/integration/components/listbox-test.js
@@ -3411,4 +3411,34 @@ module('Integration | Component | <Listbox>', function (hooks) {
 
     assert.strictEqual(callCount, 0, 'onSubmit not called');
   });
+
+  test('should be possible to prevent automatically scrolling to selected option', async function (assert) {
+    await render(hbs`
+      <Listbox @value="hulu" @preventScrollToOption={{true}} as |listbox|>
+         <listbox.Button data-test="headlessui-listbox-button-1">Trigger</listbox.Button>
+         <listbox.Options style="height: 50px; overflow:scroll;" data-test="headlessui-listbox-options-1" as |options|>
+           <options.Option @value="alice">alice</options.Option>
+           <options.Option @value="bob">bob</options.Option>
+           <options.Option @value="charlie">charlie</options.Option>
+           <options.Option @value="delta">delta</options.Option>
+           <options.Option @value="foxtrot">foxtrot</options.Option>
+           <options.Option @value="gamma">gamma</options.Option>
+           <options.Option @value="hulu">hulu</options.Option>
+         </listbox.Options>
+       </Listbox>
+    `);
+
+    // Open listbox
+    await click(getListboxButton());
+    assertListbox({ state: ListboxState.Visible });
+    await assertActiveElement(getListbox());
+
+    let options = getListboxOptions();
+
+    assert.strictEqual(
+      options[0].parentElement.scrollTop,
+      0,
+      'option is not scrolled into view'
+    );
+  });
 });


### PR DESCRIPTION
# ✨ What Changed & Why

**Current behaviour:**

`<Listbox>` always scrolls the selected option into view when the listbox opens or when the selected option changes.

**New behaviour:**

In some situations (e.g. showing extra content such as a search box inside the dropdown), we do not want to scroll the selected option into view (e.g. the search box should always be visible when the listbox opens).

This change adds a `preventScrollToOption` argument to listbox that prevents this behaviour if configured to be true.

