### PR TITLE
:bug: Refactor handle outside click for listbox - firefox issue

### DIFF
--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -74,14 +74,12 @@ export default class ListboxComponent extends Component {
 
   @action
   handleClickOutside(e) {
-    for (let i = 0; i < e.path?.length; i++) {
-      if (e.path[i] === this.buttonElement) {
-        return true;
-      }
+    let isClickOutsideButton = !e.srcElement.closest(
+      `#${this.buttonElement.id}`
+    );
+    if (isClickOutsideButton) {
+      this.closeListbox();
     }
-
-    this.closeListbox();
-
     return true;
   }
 


### PR DESCRIPTION
### **What changed and Why ?**

I noticed strange behavior using **firefox** for `<Listbox />` component:

Clicking on button when list is open – it **does not** close listbox:

https://user-images.githubusercontent.com/11621383/170648038-6c7056f2-6002-4a1b-94e7-c3ffbaae3e5a.mp4

With transition, clicking on button when list is open – it closes the listbox, but to open it again you have to click **twice**

https://user-images.githubusercontent.com/11621383/170648249-9ba802c1-510d-4460-925d-0980ce313533.mp4

You can check out our examples: [link](
https://gavinjoyce.github.io/ember-headlessui/listbox/listbox-basic)
Remember to use **firefox**

### **Code fix:**

Problem seems to be with using non-standard property `path` on JS `event`. More [here](https://stackoverflow.com/questions/39245488/event-path-is-undefined-running-in-firefox). I changed a bit of logic to use `closest` [method](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest), which supposed to be extensively compatible with browsers:


![Zrzut ekranu z 2022-05-27 09-06-28](https://user-images.githubusercontent.com/11621383/170649141-bdfb6d23-386d-4b7f-9aa7-d11bad4c14dd.png)


 ### **After fix:**

https://user-images.githubusercontent.com/11621383/170649500-b918d36a-bad4-4455-b26f-ea1eb0bfb884.mp4


https://user-images.githubusercontent.com/11621383/170649513-da09f7c4-f3d4-46e2-a099-0675eb1aa15f.mp4

When executing test (using `firefox`) [which asserts close](https://github.com/GavinJoyce/ember-headlessui/blob/master/tests/integration/components/listbox-test.js#L2843) - it fails. 

PS: We already have 37 errors when executing test suite with firefox ;( I will try to fix them in following PR's !



