### PR TITLE
:bug: <listbox/> with transtion open on "enter" click

### DIFF
--- a/addon/components/listbox.js
+++ b/addon/components/listbox.js
@@ -138,6 +138,8 @@ export default class ListboxComponent extends Component {
       } else {
         this.isOpen = true;
       }
+      event.preventDefault();
+      event.stopPropagation();
     } else if (event.key.length === 1) {
       this.addSearchCharacter(event.key);
     }

--- a/tests/integration/components/listbox-test.js
+++ b/tests/integration/components/listbox-test.js
@@ -10,6 +10,8 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, skip, test, todo } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
+import userEvent from '@testing-library/user-event';
+
 import {
   assertActiveElement,
   assertActiveListboxOption,
@@ -868,6 +870,33 @@ module('Integration | Component | <Listbox>', function (hooks) {
 
       // Verify the active option is the previously selected one
       assertActiveListboxOption(getListboxOptions()[0]);
+    });
+
+    test('should be possible to open the listbox (with transition) with "Enter"', async function (assert) {
+      await render(hbs`
+        <Listbox as |listbox|>
+           <listbox.Button data-test="headlessui-listbox-button-1">Trigger</listbox.Button>
+           <Transition
+            @show={{listbox.isOpen}}
+           >
+             <listbox.Options
+               @isOpen={{true}}
+               as |options|>
+               <options.Option>
+                Option A
+               </options.Option>
+             </listbox.Options>
+            </Transition>
+         </Listbox>`);
+
+      getListboxButton()?.focus();
+      userEvent.keyboard('{Enter}');
+
+      await assert.waitFor(async () => {
+        assertListbox({
+          state: ListboxState.Visible,
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### **What changed and why:**

Currently when using `<Listbox/>` component with composition with `<Transtion/>` it is not possible to use "Enter" key to open listbox.

Video from [demo](https://gavinjoyce.github.io/ember-headlessui/listbox/listbox-with-transition) (try yourself):  

https://user-images.githubusercontent.com/11621383/170680518-49a03b85-e6c0-43d9-a1dd-b2b39e429278.mp4

### **Fix:**

listbox with transition suffers from race condition. When “enter” click, [handler](https://github.com/GavinJoyce/ember-headlessui/blob/master/addon/components/listbox.js#L129) for `keyPress` is called – is sets flag `isOpen` to true. 
Then after a while, the [handler](https://github.com/GavinJoyce/ember-headlessui/blob/master/addon/components/listbox.js#L69) `onButtonClick` is also fired – this handler toggles `isOpen` property – so it reverts `isOpen` to false.
Everything above is executed on one “enter” click.

[link](https://github.com/GavinJoyce/ember-headlessui/runs/6623959069?check_suite_focus=true#step:7:185) to failed test.

