### PR TITLE
Remove @tailwindcss/ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@nullvoxpopuli/eslint-configs": "^1.5.1",
-    "@tailwindcss/ui": "^0.7.2",
     "@testing-library/dom": "^8.1.0",
     "@testing-library/user-event": "^13.1.9",
     "@types/ember-qunit": "^3.4.14",

--- a/tests/dummy/config/tailwind.config.js
+++ b/tests/dummy/config/tailwind.config.js
@@ -25,5 +25,4 @@ module.exports = {
     },
   },
   variants: {},
-  plugins: [require('@tailwindcss/ui')],
 };


### PR DESCRIPTION
I'm splitting certain things out of the [v2 addon conversion](https://github.com/GavinJoyce/ember-headlessui/pull/144), because -- it's revealed a lot of bonkers behaviors we've been relying on.

Mainly, `@tailwindcss/ui` is not a valid package, in that, it has a peerDepeendency on tailwindcss@v1, which we aren't using -- so with `pnpm` (coming in yet another PR), we have _strict_ peer dependencies -- which means package authors need to communicate correctly :sweat_smile: 

I think the best course of action here is to just remove `@tailwindcss/ui` as it also appears unmaintained -- last publish was 2 years ago.