### PR TITLE
:bug: <Listbox> should scroll option into view only once

### DIFF
--- a/ember-headlessui/addon/components/listbox.hbs
+++ b/ember-headlessui/addon/components/listbox.hbs
@@ -23,6 +23,8 @@
       openListbox=this.openListbox
       closeListbox=this.closeListbox
       handleClickOutside=this.handleClickOutside
+      selectedValue=@value
+      scrollIntoView=this.scrollIntoView
     )
     Button=(component
       'listbox/-button'

--- a/ember-headlessui/addon/components/listbox.js
+++ b/ember-headlessui/addon/components/listbox.js
@@ -185,7 +185,6 @@ export default class ListboxComponent extends Component {
         this.selectedOptionIndex = this.activeOptionIndex =
           this.optionElements.length - 1;
 
-        this.scrollIntoView(optionElement);
       }
     }
 

--- a/ember-headlessui/addon/components/listbox.js
+++ b/ember-headlessui/addon/components/listbox.js
@@ -184,7 +184,6 @@ export default class ListboxComponent extends Component {
       if (this.args.value === optionComponent.args.value) {
         this.selectedOptionIndex = this.activeOptionIndex =
           this.optionElements.length - 1;
-
       }
     }
 

--- a/ember-headlessui/addon/components/listbox/-option.hbs
+++ b/ember-headlessui/addon/components/listbox/-option.hbs
@@ -4,6 +4,7 @@
     id={{this.guid}}
     tabindex='-1'
     {{this.registerOption}}
+    {{this.scroll this.shouldScroll @scrollIntoView}}
     {{on 'focus' (fn @setActiveOption this)}}
     {{on 'mouseover' (fn @setActiveOption this)}}
     {{on 'mouseout' @unsetActiveOption}}

--- a/ember-headlessui/addon/components/listbox/-option.js
+++ b/ember-headlessui/addon/components/listbox/-option.js
@@ -7,9 +7,21 @@ import { modifier } from 'ember-modifier';
 
 export default class ListboxOptionComponent extends Component {
   @tracked guid = `${guidFor(this)}-headlessui-listbox-option`;
+  @tracked shouldScroll = false;
+
+  constructor() {
+    super(...arguments);
+    this.shouldScroll = this.args.selectedValue === this.args.value;
+  }
 
   registerOption = modifier((element) => {
     this.args.registerOptionElement(this, element);
+  });
+
+  scroll = modifier((element, [shouldScroll, scrollFn]) => {
+    if (shouldScroll) {
+      scrollFn(element);
+    }
   });
 
   @action

--- a/ember-headlessui/addon/components/listbox/-options.hbs
+++ b/ember-headlessui/addon/components/listbox/-options.hbs
@@ -32,6 +32,8 @@
             setActiveOption=@setActiveOption
             unsetActiveOption=@unsetActiveOption
             setSelectedOption=@setSelectedOption
+            selectedValue=@selectedValue
+            scrollIntoView=@scrollIntoView
           )
         )
       }}

--- a/test-app/tests/integration/components/listbox-test.js
+++ b/test-app/tests/integration/components/listbox-test.js
@@ -3445,27 +3445,27 @@ module('Integration | Component | <Listbox>', function (hooks) {
     this.set('items', [1, 2, 3, 4]);
     this.set('selected', 1);
     this.set('select', (item) => {
-      this.set('first', item);
+      this.selected = item;
     });
 
     let factory = this.owner.factoryFor('component:listbox');
     let callCount = 0;
-    class Extended extends factory.class {
+    class ExtendedListbox extends factory.class {
       scrollIntoView() {
         callCount++;
       }
     }
 
     this.owner.unregister('component:listbox');
-    this.owner.register('component:listbox', Extended);
+    this.owner.register('component:listbox', ExtendedListbox);
 
     await render(hbs`
       <Listbox @onChange={{this.select}} @value={{this.selected}} as |listbox|>
         <listbox.Button>Trigger</listbox.Button>
         <listbox.Options as |options|>
           {{#each this.items as |item|}}
-            <options.Option @value={{item}} @disabled={{item.unavilable}} as |option|>
-              {{item.name}} {{option.selected}}
+            <options.Option @value={{item}} as |option|>
+              {{item}}
             </options.Option>
           {{/each}}
         </listbox.Options>

--- a/test-app/tests/integration/components/listbox-test.js
+++ b/test-app/tests/integration/components/listbox-test.js
@@ -3440,4 +3440,42 @@ module('Integration | Component | <Listbox>', function (hooks) {
 
     assert.strictEqual(callCount, 0, 'onSubmit not called');
   });
+
+  test('should scroll to selected item only once', async function (assert) {
+    this.set('items', [1, 2, 3, 4]);
+    this.set('selected', 1);
+    this.set('select', (item) => {
+      this.set('first', item);
+    });
+
+    let factory = this.owner.factoryFor('component:listbox');
+    let callCount = 0;
+    class Extended extends factory.class {
+      scrollIntoView() {
+        callCount++;
+      }
+    }
+
+    this.owner.unregister('component:listbox');
+    this.owner.register('component:listbox', Extended);
+
+    await render(hbs`
+      <Listbox @onChange={{this.select}} @value={{this.selected}} as |listbox|>
+        <listbox.Button>Trigger</listbox.Button>
+        <listbox.Options as |options|>
+          {{#each this.items as |item|}}
+            <options.Option @value={{item}} @disabled={{item.unavilable}} as |option|>
+              {{item.name}} {{option.selected}}
+            </options.Option>
+          {{/each}}
+        </listbox.Options>
+      </Listbox>
+    `);
+
+    await click(getListboxButton());
+    let options = getListboxOptions();
+    await click(options[2]);
+
+    assert.strictEqual(callCount, 1, 'called exactly once');
+  });
 });


### PR DESCRIPTION
Failing test reference: [click](https://github.com/GavinJoyce/ember-headlessui/actions/runs/3707544456/jobs/6284104779#step:7:726)

fixes: #137 

### **Issue:**

In this repo, we vastly used the pattern "register children elements" in [modifier](https://github.com/GavinJoyce/ember-headlessui/blob/master/ember-headlessui/addon/components/listbox.js#L174). Then when in modifier callback, we use `this.args.*` it will be reevaluated when that `args` changes <-- this is desired behavior.
But because of this mechanism, we have to be very careful what functions are called inside modifier. This bug is caused by calling `this.scrollIntoView` more than once. It affects the situation when user selects a new value (test) or new options are lazy loaded.

### **Solution:**

It turns out that we can scroll `listbox option` into viewport not from root component, but delegate it to children (`option`). There is an only one moment when option should be scrolled (when is selected – what is being checked in constructor of `option`). 

### **Before:**

Lazy loaded options with "jumpy" effect when promise resolved:

https://user-images.githubusercontent.com/11621383/208042239-f82d6d06-7fe1-4bbb-aeef-be64e91cb9cd.mp4


### **After:**


https://user-images.githubusercontent.com/11621383/208042199-cebf7586-679d-4130-9fbe-0475deb62da6.mp4


