### PR TITLE
Fix closing animated modal

### DIFF
--- a/test-app/app/templates/dialog/dialog-modal-with-transition.hbs
+++ b/test-app/app/templates/dialog/dialog-modal-with-transition.hbs
@@ -39,7 +39,6 @@
           @leave='ease-in duration-200'
           @leaveFrom='opacity-100 scale-100'
           @leaveTo='opacity-0 scale-95'
-          class='transition-all transform'
         >
           {{! This element is to trick the browser into centering the modal contents. }}
           <span


### PR DESCRIPTION
This seems to fix being able to close the modal by clicking the overlay.

Closes #172 