### PR TITLE
FIX: add default type='button' to switch

### DIFF
--- a/ember-headlessui/addon/components/switch/button.hbs
+++ b/ember-headlessui/addon/components/switch/button.hbs
@@ -3,6 +3,7 @@
     id={{@guid}}
     role='switch'
     tabindex='0'
+    type='button'
     aria-checked='{{@isOn}}'
     aria-labelledby={{@labelGuid}}
     ...attributes

--- a/test-app/tests/integration/components/switch-test.js
+++ b/test-app/tests/integration/components/switch-test.js
@@ -50,6 +50,10 @@ function assertSwitchState(
     assert.dom(labelSelector).hasText(options.labelText);
   }
 
+  if (options.type) {
+    assert.dom(buttonSelector).hasAttribute('type', options.type);
+  }
+
   switch (options.state) {
     case SwitchState.On:
       assertSwitchIsOn(selector);
@@ -117,6 +121,28 @@ module('Integration | Component | <Switch>', function (hooks) {
         state: SwitchState.Off,
         text: 'Off',
         buttonTagName: 'span',
+      });
+    });
+
+    module('`type` attribute', function () {
+      test('should set the `type` to "button" by default', async function () {
+        await render(hbs`
+          <Switch @isOn={{false}} data-test-switch as |switch|>
+            <switch.Button />
+          </Switch>
+        `);
+
+        assertSwitchState({ type: 'button' });
+      });
+
+      test('should not set the `type` to "button" if it already contains a `type`', async function () {
+        await render(hbs`
+          <Switch @isOn={{false}} data-test-switch as |switch|>
+            <switch.Button type="submit" />
+          </Switch>
+        `);
+
+        assertSwitchState({ type: 'submit' });
       });
     });
   });


### PR DESCRIPTION
Because, when used inside form the switch button reacts to clicks on Enter