### PR TITLE
Fix ember-modifier import path

### DIFF
--- a/ember-headlessui/addon/components/menu/item.js
+++ b/ember-headlessui/addon/components/menu/item.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 
-import { modifier } from 'ember-modifier/.';
+import { modifier } from 'ember-modifier';
 
 export default class Item extends Component {
   guid = `${guidFor(this)}-tailwindui-menu-item`;


### PR DESCRIPTION
Quite curious it doesn't break addon tests but it breaks when trying to implement in an app.