### PR TITLE
Add shadow DOM support to the menu component

### DIFF
--- a/ember-headlessui/addon/components/menu.js
+++ b/ember-headlessui/addon/components/menu.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 
@@ -133,7 +134,12 @@ export default class Menu extends Component {
   }
 
   get itemsElement() {
-    return document.getElementById(this.itemsGuid);
+    return (
+      document.getElementById(this.itemsGuid) ??
+      getOwner(this).rootElement.querySelector?.(
+        `[id="${this.args.itemsGuid}"]`
+      )
+    );
   }
 
   get buttonGuid() {
@@ -141,6 +147,11 @@ export default class Menu extends Component {
   }
 
   get buttonElement() {
-    return document.getElementById(this.buttonGuid);
+    return (
+      document.getElementById(this.buttonGuid) ??
+      getOwner(this).rootElement.querySelector?.(
+        `[id="${this.args.buttonGuid}"]`
+      )
+    );
   }
 }

--- a/ember-headlessui/addon/components/menu/items.hbs
+++ b/ember-headlessui/addon/components/menu/items.hbs
@@ -12,8 +12,8 @@
       focusTrapOptions=(hash
         allowOutsideClick=this.allowClickOutsideFocusTrap
         clickOutsideDeactivates=this.clickOutsideFocusTrapDeactivates
-        fallbackFocus=this.menuItemsElementSelector
-        initialFocus=this.menuItemsElementSelector
+        fallbackFocus=this.menuItemsElement
+        initialFocus=this.menuItemsElement
         onDeactivate=@closeMenu
       )
     }}

--- a/ember-headlessui/addon/components/menu/items.js
+++ b/ember-headlessui/addon/components/menu/items.js
@@ -1,11 +1,17 @@
 import Component from '@glimmer/component';
+import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 
 import { Keys } from 'ember-headlessui/utils/keyboard';
 
 export default class Items extends Component {
-  get menuItemsElementSelector() {
-    return `#${this.args.itemsGuid}`;
+  get menuItemsElement() {
+    return (
+      document.getElementById(this.itemsGuid) ??
+      getOwner(this).rootElement.querySelector?.(
+        `[id="${this.args.itemsGuid}"]`
+      )
+    );
   }
 
   @action
@@ -52,10 +58,16 @@ export default class Items extends Component {
   }
 
   clickInsideMenuTrigger(event) {
-    const buttonElement = document.getElementById(this.args.buttonGuid);
+    const buttonElement =
+      document.getElementById(this.args.buttonGuid) ??
+      getOwner(this).rootElement.querySelector?.(
+        `[id="${this.args.buttonGuid}"]`
+      );
 
     // The `buttonElement` could not exist if the element has been removed from the DOM
-    return buttonElement ? buttonElement.contains(event.target) : false;
+    return buttonElement
+      ? buttonElement.contains(event.composedPath()[0])
+      : false;
   }
 
   @action


### PR DESCRIPTION
This PR starts implementing basic Shadow DOM support for the menu item component. It misses proper Shadow DOM tests and documentation which I'll be happy to add once I receive general approval from the addon's maintainers.

It covers the case where we want to wrap the entire ember application within a Shadow DOM, useful when we want to embed it within other web pages.