### PR TITLE
Fix Combobox emitting spurious onChange events

### DIFF
--- a/ember-headlessui/addon/components/combobox.js
+++ b/ember-headlessui/addon/components/combobox.js
@@ -76,8 +76,6 @@ export default class ComboboxComponent extends Component {
   set isOpen(isOpen) {
     if (this.isDisabled) return;
 
-    this.inputComponent?.clearInput();
-
     if (!isOpen) {
       this._activeOptionGuid = null;
       this.optionElements = [];

--- a/ember-headlessui/addon/components/combobox/-input.js
+++ b/ember-headlessui/addon/components/combobox/-input.js
@@ -22,9 +22,4 @@ export default class ComboboxInputComponent extends Component {
     this.args.handleInput(event);
     this.args.onChange?.(event);
   }
-
-  @action
-  clearInput() {
-    this.args.onChange?.({ target: { value: '' } });
-  }
 }


### PR DESCRIPTION
## Summary
Fixes #187 - The Combobox component was incorrectly firing `onChange` events with empty values every time the dropdown opened or closed.

## Changes
- Remove `clearInput()` method from `combobox/-input.js` which was calling `onChange` with an empty value
- Remove call to `clearInput()` from `combobox.js` `isOpen` setter
- Add test to verify opening/closing the combobox doesn't trigger spurious `onChange` events

## Root Cause
The `clearInput()` method was being called every time `isOpen` was set, and it would trigger `onChange({ target: { value: '' } })`. This caused the user's `onChange` handler to fire as if the user had typed an empty string, when in reality no user input had occurred.

## Testing
1. Run `npm test -- --filter="opening and closing the combobox should not trigger spurious onChange"` 
2. Or manually test at `/combobox/combobox-basic` - opening/closing the dropdown should not trigger the input's onChange handler