### PR TITLE
Remove incomplete menu-with-popper demo pages

### DIFF
--- a/test-app/app/router.js
+++ b/test-app/app/router.js
@@ -10,9 +10,7 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('menu', function () {
     this.route('menu-basic');
-    this.route('menu-with-popper');
     this.route('menu-with-transition');
-    this.route('menu-with-transition-and-popper');
   });
 
   this.route('listbox', function () {

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -16,18 +16,8 @@
             </LinkTo>
           </li>
           <li>
-            <LinkTo @route='menu.menu-with-popper'>
-              Menu with Popper [todo]
-            </LinkTo>
-          </li>
-          <li>
             <LinkTo @route='menu.menu-with-transition'>
               Menu with Transition
-            </LinkTo>
-          </li>
-          <li>
-            <LinkTo @route='menu.menu-with-transition-and-popper'>
-              Menu with Popper + Transition [todo]
             </LinkTo>
           </li>
         </ul>

--- a/test-app/app/templates/menu/menu-with-popper.hbs
+++ b/test-app/app/templates/menu/menu-with-popper.hbs
@@ -1,1 +1,0 @@
-menu-with-popper will go here

--- a/test-app/app/templates/menu/menu-with-transition-and-popper.hbs
+++ b/test-app/app/templates/menu/menu-with-transition-and-popper.hbs
@@ -1,1 +1,0 @@
-menu-with-transition-and-popper will go here


### PR DESCRIPTION
## Summary
Removes placeholder TODO links from the demo site navigation that pointed to unimplemented pages.

## Changes
- Remove "Menu with Popper [todo]" link from index page
- Remove "Menu with Popper + Transition [todo]" link from index page
- Delete unused template files: `menu-with-popper.hbs` and `menu-with-transition-and-popper.hbs`
- Remove corresponding route definitions from router.js

## Testing
- Visit the demo site and verify the menu section only shows "Menu (basic)" and "Menu with Transition" links
- Confirm no broken routes or 404 errors