### PR TITLE
Fix build:docs to target test-app instead of addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:ember": "pnpm --filter test-app run start",
     "dev:addon": "echo 'pnpm run --filter ember-headlessui start --no-watch.clearScreen'",
     "dev:docs": "echo 'pnpm run --filter docs docs:watch --preserveWatchOutput'",
-    "build:docs": "pnpm --filter ember-headlessui run build",
+    "build:docs": "pnpm --filter test-app run build",
     "release": "pnpm --filter ember-headlessui run release",
     "lint": "pnpm --filter '*' lint",
     "lint:fix": "pnpm --filter '*' lint:fix",


### PR DESCRIPTION
## Summary
Fixes the `build:docs` script to build the correct package for GitHub Pages deployment.

## Changes
- Changed `build:docs` from `pnpm --filter ember-headlessui run build` to `pnpm --filter test-app run build`

## Context
After the monorepo restructuring (commit d922d51), the docs/demo site was moved from the addon's dummy app to `test-app`. However, the `build:docs` script was never updated to reflect this change.

The `docs.yml` workflow deploys `test-app/dist` to GitHub Pages, but `build:docs` was building the addon (which has no app to build), causing the deployment to fail with a missing `index.html` error.

## Testing
- Run `pnpm build:docs` - should now build `test-app` successfully
- The GitHub Pages deployment workflow should complete without errors