### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 
 .github/
 .pnpm-debug.log
+.env


### PR DESCRIPTION
## Summary
Adds `.env` to the gitignore file to prevent accidentally committing secrets like the `GITHUB_AUTH` token used for releases.

## Changes
- Added `.env` to `.gitignore`

## Testing
- Verify `.env` files are no longer tracked by git