### PR TITLE
Add changelog repo config for lerna-changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   "volta": {
     "node": "18.17.0",
     "pnpm": "7.33.5"
+  },
+  "changelog": {
+    "repo": "GavinJoyce/ember-headlessui"
   }
 }


### PR DESCRIPTION
## Summary
Fixes lerna-changelog repo detection in monorepo setup by explicitly configuring the repo in the root package.json.

## Changes
- Added `changelog.repo` config to root `package.json` so lerna-changelog can find the GitHub repo

## Testing
- Run `pnpm release` and verify lerna-changelog generates the changelog correctly