### PR TITLE
Fix listbox keyboard navigation when no default value is set

### DIFF
--- a/ember-headlessui/addon/components/listbox.js
+++ b/ember-headlessui/addon/components/listbox.js
@@ -269,11 +269,10 @@ export default class ListboxComponent extends Component {
   }
 
   setNextOptionActive() {
-    for (
-      let i = this.activeOptionIndex + 1;
-      i < this.optionElements.length;
-      i++
-    ) {
+    let nextActiveOptionIndex =
+      this.activeOptionIndex !== undefined ? this.activeOptionIndex + 1 : 0;
+
+    for (let i = nextActiveOptionIndex; i < this.optionElements.length; i++) {
       if (!this.optionElements[i].hasAttribute('disabled')) {
         this.activeOptionIndex = i;
         break;
@@ -282,7 +281,12 @@ export default class ListboxComponent extends Component {
   }
 
   setPreviousOptionActive() {
-    for (let i = this.activeOptionIndex - 1; i >= 0; i--) {
+    let previousActiveOptionIndex =
+      this.activeOptionIndex !== undefined
+        ? this.activeOptionIndex - 1
+        : this.optionElements.length - 1;
+
+    for (let i = previousActiveOptionIndex; i >= 0; i--) {
       if (!this.optionElements[i].hasAttribute('disabled')) {
         this.activeOptionIndex = i;
         break;

--- a/test-app/tests/integration/components/listbox-test.js
+++ b/test-app/tests/integration/components/listbox-test.js
@@ -1552,6 +1552,106 @@ module('Integration | Component | <Listbox>', function (hooks) {
       options.forEach((option) => assertListboxOption({}, option));
       assertActiveListboxOption(options[2]);
     });
+
+    test('should be possible to use ArrowDown to navigate when listbox has no default value and was opened via click', async function (assert) {
+      await render(hbs`
+        <Listbox as |listbox|>
+           <listbox.Button data-test="headlessui-listbox-button-1">Trigger</listbox.Button>
+           <listbox.Options data-test="headlessui-listbox-options-1" as |options|>
+             <options.Option @value="a">
+               Option A
+             </options.Option>
+             <options.Option @value="b">
+               Option B
+             </options.Option>
+             <options.Option @value="c">
+               Option C
+             </options.Option>
+           </listbox.Options>
+         </Listbox>
+      `);
+
+      assertListboxButton({
+        state: ListboxState.InvisibleUnmounted,
+        attributes: { 'data-test': 'headlessui-listbox-button-1' },
+      });
+      assertListbox({ state: ListboxState.InvisibleUnmounted });
+
+      // Open listbox via click (not keyboard) - this sets activateBehaviour to ACTIVATE_NONE
+      await click(getListboxButton());
+
+      // Verify it is visible
+      assertListboxButton({ state: ListboxState.Visible });
+      assertListbox({
+        state: ListboxState.Visible,
+        attributes: { 'data-test': 'headlessui-listbox-options-1' },
+      });
+
+      // Verify we have listbox options
+      let options = getListboxOptions();
+      assert.strictEqual(options.length, 3);
+
+      // No option should be active initially (since no @value and opened via click)
+      assertNoActiveListboxOption();
+
+      // Press ArrowDown - this should activate the first option
+      await triggerKeyEvent(getListbox(), 'keyup', 'ArrowDown');
+      assertActiveListboxOption(options[0]);
+
+      // Press ArrowDown again - should move to second option
+      await triggerKeyEvent(getListbox(), 'keyup', 'ArrowDown');
+      assertActiveListboxOption(options[1]);
+    });
+
+    test('should be possible to use ArrowUp to navigate when listbox has no default value and was opened via click', async function (assert) {
+      await render(hbs`
+        <Listbox as |listbox|>
+           <listbox.Button data-test="headlessui-listbox-button-1">Trigger</listbox.Button>
+           <listbox.Options data-test="headlessui-listbox-options-1" as |options|>
+             <options.Option @value="a">
+               Option A
+             </options.Option>
+             <options.Option @value="b">
+               Option B
+             </options.Option>
+             <options.Option @value="c">
+               Option C
+             </options.Option>
+           </listbox.Options>
+         </Listbox>
+      `);
+
+      assertListboxButton({
+        state: ListboxState.InvisibleUnmounted,
+        attributes: { 'data-test': 'headlessui-listbox-button-1' },
+      });
+      assertListbox({ state: ListboxState.InvisibleUnmounted });
+
+      // Open listbox via click (not keyboard) - this sets activateBehaviour to ACTIVATE_NONE
+      await click(getListboxButton());
+
+      // Verify it is visible
+      assertListboxButton({ state: ListboxState.Visible });
+      assertListbox({
+        state: ListboxState.Visible,
+        attributes: { 'data-test': 'headlessui-listbox-options-1' },
+      });
+
+      // Verify we have listbox options
+      let options = getListboxOptions();
+      assert.strictEqual(options.length, 3);
+
+      // No option should be active initially (since no @value and opened via click)
+      assertNoActiveListboxOption();
+
+      // Press ArrowUp - this should activate the last option
+      await triggerKeyEvent(getListbox(), 'keyup', 'ArrowUp');
+      assertActiveListboxOption(options[2]);
+
+      // Press ArrowUp again - should move to second option
+      await triggerKeyEvent(getListbox(), 'keyup', 'ArrowUp');
+      assertActiveListboxOption(options[1]);
+    });
   });
 
   module('Listbox `ArrowRight` key', () => {


### PR DESCRIPTION
## Summary

Fixes the bug originally reported in #82.

**Problem:** When a listbox has no default `@value` and is opened via click (not keyboard), pressing `ArrowDown` or `ArrowUp` does not navigate through the options.

**Root Cause:** When opening via click, `handleButtonClick` sets `activateBehaviour = ACTIVATE_NONE`, so no option is initially activated. This leaves `activeOptionIndex` as `undefined`. When the user presses ArrowDown, `setNextOptionActive()` was called with:

```javascript
for (let i = this.activeOptionIndex + 1; ...) // undefined + 1 = NaN
```

Since `NaN` doesn't satisfy the loop condition, no option was activated.

**Fix:** Check if `activeOptionIndex` is `undefined` and start from:
- Index 0 for `setNextOptionActive()` (first option)  
- Last index for `setPreviousOptionActive()` (last option)

## Test Plan

- [x] `npx ember test --filter "should be possible to use ArrowDown to navigate when listbox has no default value"` - **Passes**
- [x] `npx ember test --filter "should be possible to use ArrowUp to navigate when listbox has no default value"` - **Passes**

## Related

- Original PR with the fix: #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)