### PR TITLE
Add clear selection button and more names to combobox example

### DIFF
--- a/test-app/app/controllers/combobox/combobox-basic.js
+++ b/test-app/app/controllers/combobox/combobox-basic.js
@@ -8,6 +8,21 @@ const PEOPLE = [
   { id: 3, name: 'Therese Wunsch', unavailable: false },
   { id: 4, name: 'Benedict Kessler', unavailable: true },
   { id: 5, name: 'Katelyn Rohan', unavailable: false },
+  { id: 6, name: 'Alicia Waters', unavailable: false },
+  { id: 7, name: 'Marcus Chen', unavailable: false },
+  { id: 8, name: 'Priya Sharma', unavailable: false },
+  { id: 9, name: 'Oliver Grant', unavailable: true },
+  { id: 10, name: 'Sofia Ramirez', unavailable: false },
+  { id: 11, name: "James O'Brien", unavailable: false },
+  { id: 12, name: 'Yuki Tanaka', unavailable: false },
+  { id: 13, name: 'Elena Petrova', unavailable: false },
+  { id: 14, name: 'David Kim', unavailable: false },
+  { id: 15, name: 'Fatima Al-Hassan', unavailable: false },
+  { id: 16, name: 'Lucas Fernandez', unavailable: true },
+  { id: 17, name: 'Amara Okafor', unavailable: false },
+  { id: 18, name: 'Henrik Larsson', unavailable: false },
+  { id: 19, name: 'Mei Lin', unavailable: false },
+  { id: 20, name: 'Noah Patel', unavailable: false },
 ];
 
 export default class ComboboxBasicController extends Controller {
@@ -27,6 +42,12 @@ export default class ComboboxBasicController extends Controller {
   @action
   setSelectedPerson(person) {
     this.selectedPerson = person;
+  }
+
+  @action
+  clearSelection() {
+    this.selectedPerson = null;
+    this._filter = '';
   }
 
   @action

--- a/test-app/app/templates/combobox/combobox-basic.hbs
+++ b/test-app/app/templates/combobox/combobox-basic.hbs
@@ -15,6 +15,28 @@
           @displayValue={{this.displayValue}}
           class='inline-flex h-9 border border-gray-300 rounded-md rounded-r-none border-r-0 outline-none pl-3 w-full'
         />
+        {{#if this.selectedPerson}}
+          <button
+            type='button'
+            class='h-9 inline-flex items-center px-1 text-gray-400 hover:text-gray-600 bg-white border border-gray-300 border-l-0 border-r-0'
+            {{on 'click' this.clearSelection}}
+          >
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              class='h-4 w-4'
+              fill='none'
+              viewBox='0 0 24 24'
+              stroke='currentColor'
+            >
+              <path
+                stroke-linecap='round'
+                stroke-linejoin='round'
+                stroke-width='2'
+                d='M6 18L18 6M6 6l12 12'
+              ></path>
+            </svg>
+          </button>
+        {{/if}}
         <combobox.Button
           class='h-9 rounded-l-none border-l-0 inline-flex justify-center w-22 px-2 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800'
         >


### PR DESCRIPTION
## Summary
Add an X clear button to the combobox-basic example and expand the people list from 5 to 20 names.

## Changes
- Added a clear (X) button between the input and chevron button that resets the selection
- Expanded the PEOPLE array from 5 to 20 names with diverse entries
- Added `clearSelection` action that sets selectedPerson to null and resets the filter

## Testing
- Visit /combobox/combobox-basic
- Verify 20 names appear in the dropdown
- Select a person, then click the X button to clear the selection
- Verify the X button only appears when a person is selected