### PR TITLE
Add event to the dialog onClose action

### DIFF
--- a/ember-headlessui/addon/components/dialog.ts
+++ b/ember-headlessui/addon/components/dialog.ts
@@ -13,7 +13,7 @@ import type DialogStackProvider from 'ember-headlessui/services/dialog-stack-pro
 
 interface Args {
   isOpen: boolean;
-  onClose: () => void;
+  onClose: (event: Event) => void;
   as: string | typeof Component;
 }
 
@@ -35,7 +35,7 @@ export default class DialogComponent extends Component<Args> {
   });
 
   handleEscapeKey = modifier(
-    (_element, [isOpen, onClose]: [boolean, () => void]) => {
+    (_element, [isOpen, onClose]: [boolean, (event: Event) => void]) => {
       let handler = (event: KeyboardEvent) => {
         if (event.key !== Keys.Escape) return;
         if (!isOpen) return;
@@ -43,7 +43,7 @@ export default class DialogComponent extends Component<Args> {
         event.preventDefault();
         event.stopPropagation();
 
-        onClose();
+        onClose(event);
       };
 
       window.addEventListener('keyup', handler);
@@ -155,14 +155,14 @@ export default class DialogComponent extends Component<Args> {
       this.outsideClickedElement = target;
     }
 
-    this.onClose();
+    this.onClose(e);
 
     return true;
   }
 
   @action
-  onClose() {
+  onClose(event: Event) {
     if (this.dialogStackProvider.hasOpenChild(this)) return;
-    this.args.onClose();
+    this.args.onClose(event);
   }
 }

--- a/ember-headlessui/addon/components/dialog/-overlay.js
+++ b/ember-headlessui/addon/components/dialog/-overlay.js
@@ -26,6 +26,6 @@ export default class DialogOverlayComponent extends Component {
     event.preventDefault();
     event.stopPropagation();
 
-    onClose();
+    onClose(event);
   }
 }


### PR DESCRIPTION
This updates the `onClose` action for the `Dialog` component so that it passes the event with it. This will allow users to choose whether or not they want the dialog to close. A good example of this is if a user wants to prevent closing the dialog when clicking the overlay.

```handlebars
<button type="button" {{on "click" (set this "isOpen" true)}}>
  Trigger
</button>

<Dialog
  @isOpen={{this.isOpen}}
  @onClose={{this.handleClose}} as |d|
>
  <d.Overlay data-dialog-overlay />
  Contents
  <div tabindex="0"></div>
</Dialog>
```

```typescript
handleClose(event: Event) {
  let target = event.target as HTMLElement;

  if (target.hasAttribute('data-dialog-overlay')) return;
  this.isOpen = false;
}
```

---

### Original implementation

This adds a new optional argument to the `Dialog` component called `@closeOnOutsideClick` that will allow you to prevent closing the `Dialog` if you click the `Overlay` component or if you click outside the `Dialog`. This new argument defaults to `true` to preserve the existing behavior of always closing on outside click.

Here is an example using the new argument:

```handlebars
<button type="button" {{on "click" (set this "isOpen" true)}}>
  Trigger
</button>

<Dialog
  @isOpen={{this.isOpen}}
  @onClose={{set this "isOpen" false}}
  @closeOnOutsideClick={{false}} as |d|
>
  <d.Overlay />
  Contents
  <div tabindex="0"></div>
</Dialog>
```