### PR TITLE
Guard Listbox scrollIntoView against options removed from the DOM

### DIFF
--- a/ember-headlessui/addon/components/listbox.js
+++ b/ember-headlessui/addon/components/listbox.js
@@ -281,6 +281,13 @@ export default class ListboxComponent extends Component {
   }
 
   scrollIntoView(optionElement) {
+    // The option may have been removed from the DOM by a re-render while
+    // still registered with the listbox (e.g. search/type-ahead racing a
+    // re-render) — without a parent there is nothing to scroll.
+    if (!optionElement.parentElement) {
+      return;
+    }
+
     // Cannot use optionElement.scrollIntoView() here because that function
     // also scrolls the *window* by some amount. Here, we don't want to
     // jerk the window, we just want to make the the option element visible

--- a/test-app/tests/integration/components/listbox-test.js
+++ b/test-app/tests/integration/components/listbox-test.js
@@ -2757,6 +2757,32 @@ module('Integration | Component | <Listbox>', function (hooks) {
       assertActiveListboxOption(options[2]);
     });
 
+    test('should ignore options that are no longer in the DOM', async function () {
+      await render(hbs`
+        <Listbox as |listbox|>
+           <listbox.Button data-test="headlessui-listbox-button-1">Trigger</listbox.Button>
+           <listbox.Options data-test="headlessui-listbox-options-1" as |options|>
+             <options.Option @value="alice">alice</options.Option>
+             <options.Option @value="bob">bob</options.Option>
+           </listbox.Options>
+         </Listbox>
+      `);
+
+      // Open listbox
+      await click(getListboxButton());
+
+      let options = getListboxOptions();
+
+      // Simulate a re-render race: the option's element leaves the DOM
+      // while the listbox still has it registered
+      options[0].remove();
+
+      // Searching for the detached option must not throw
+      await typeWord('alice');
+
+      assertListbox({ state: ListboxState.Visible });
+    });
+
     test('should be possible to search for a word (case insensitive)', async function () {
       await render(hbs`
         <Listbox as |listbox|>


### PR DESCRIPTION
## The bug

`Listbox`'s type-ahead search can race a re-render: `addSearchCharacter` matches against `this.optionElements`, but a matched option's element may have already left the DOM while still registered. `scrollIntoView` then dereferences `optionElement.parentElement` (null) and throws:

```
TypeError: Cannot read properties of null (reading 'scroll')
```

We hit this in production at Phorest (tracked in our Sentry; worked around with an app-level subclass in phorest/consultation-webapp#1059). The fix belongs here so every consumer gets it.

## The fix

`scrollIntoView` returns early when the option has no `parentElement` — there's nothing to scroll to for a detached element. Type-ahead behaviour over attached options is unchanged.

Includes a regression test in the `Listbox \`Any\` key aka search` module: open the listbox, detach an option element directly (simulating the re-render race), then type-ahead for it — previously threw, now no-ops with the listbox still open.

## Note on running tests locally

A fresh `pnpm install` from the committed lockfile currently fails the test-app webpack build on an unrelated issue — `testdouble`'s `lib/can-register-loader.js` does `require('module')`, which webpack 5 can't resolve for the browser and which isn't covered by testdouble's `browser` field mapping. I validated the change behaviourally in our app's test suite against the unpatched addon (test red with the exact production error, green with the guard) and via lint; relying on CI here for the full suite. Happy to dig into the testdouble/webpack issue separately if it also bites CI.