### PR TITLE
Skip detached listbox options during typeahead

### DIFF
--- a/ember-headlessui/addon/components/listbox.hbs
+++ b/ember-headlessui/addon/components/listbox.hbs
@@ -9,6 +9,7 @@
       isOpen=this.isOpen
       guid=this.guid
       registerOptionElement=this.registerOptionElement
+      unregisterOptionElement=this.unregisterOptionElement
       registerOptionsElement=this.registerOptionsElement
       unregisterOptionsElement=this.unregisterOptionsElement
       hasLabelElement=this.labelElement

--- a/ember-headlessui/addon/components/listbox.js
+++ b/ember-headlessui/addon/components/listbox.js
@@ -196,6 +196,44 @@ export default class ListboxComponent extends Component {
     scheduleOnce('afterRender', this, this.setDefaultActiveOption);
   }
 
+  @action
+  unregisterOptionElement(optionComponent, optionElement) {
+    let removedIndex = this.optionElements.findIndex((element) => {
+      return element === optionElement;
+    });
+
+    if (removedIndex === -1) {
+      return;
+    }
+
+    this.optionElements = this.optionElements.filter((element) => {
+      return element !== optionElement;
+    });
+
+    this.optionComponents = this.optionComponents.filter((component) => {
+      return component !== optionComponent;
+    });
+
+    this.optionComponents.forEach((component, index) => {
+      let element = this.optionElements[index];
+
+      component.index = index;
+      element.setAttribute('data-index', index);
+    });
+
+    if (this.activeOptionIndex === removedIndex) {
+      this.activeOptionIndex = undefined;
+    } else if (this.activeOptionIndex > removedIndex) {
+      this.activeOptionIndex--;
+    }
+
+    let selectedIndexes = this.optionComponents
+      .filter((option) => option.isSelected)
+      .map((option) => option.index);
+
+    this.selectedOptionIndexes = new TrackedSet(selectedIndexes);
+  }
+
   setDefaultActiveOption() {
     let selectedIndexes = this.optionComponents
       .filter((o) => o.isSelected)
@@ -361,6 +399,7 @@ export default class ListboxComponent extends Component {
       let optionElement = this.optionElements[i];
 
       if (
+        optionElement.isConnected &&
         !optionElement.hasAttribute('disabled') &&
         optionElement.textContent.trim().toLowerCase().startsWith(this.search)
       ) {

--- a/ember-headlessui/addon/components/listbox/-option.js
+++ b/ember-headlessui/addon/components/listbox/-option.js
@@ -23,6 +23,10 @@ export default class ListboxOptionComponent extends Component {
 
   registerOption = modifier((element) => {
     this.args.registerOptionElement(this, element);
+
+    return () => {
+      this.args.unregisterOptionElement(this, element);
+    };
   });
 
   scroll = modifier((element, [shouldScroll, scrollFn]) => {

--- a/ember-headlessui/addon/components/listbox/-options.hbs
+++ b/ember-headlessui/addon/components/listbox/-options.hbs
@@ -28,6 +28,7 @@
           Option=(component
             'listbox/-option'
             registerOptionElement=@registerOptionElement
+            unregisterOptionElement=@unregisterOptionElement
             activeOptionGuid=@activeOptionGuid
             selectedOptionGuids=@selectedOptionGuids
             setActiveOption=@setActiveOption

--- a/test-app/tests/integration/components/listbox-test.js
+++ b/test-app/tests/integration/components/listbox-test.js
@@ -3,6 +3,7 @@ import {
   click,
   focus,
   render,
+  settled,
   triggerEvent,
   triggerKeyEvent,
 } from '@ember/test-helpers';
@@ -2757,12 +2758,19 @@ module('Integration | Component | <Listbox>', function (hooks) {
       assertActiveListboxOption(options[2]);
     });
 
-    test('should ignore options that are no longer in the DOM', async function () {
+    test('should unregister options that are no longer in the DOM', async function (assert) {
+      this.set('showAlice', true);
+      this.set('onChange', () => {
+        assert.step('onChange');
+      });
+
       await render(hbs`
-        <Listbox as |listbox|>
+        <Listbox @onChange={{this.onChange}} as |listbox|>
            <listbox.Button data-test="headlessui-listbox-button-1">Trigger</listbox.Button>
            <listbox.Options data-test="headlessui-listbox-options-1" as |options|>
-             <options.Option @value="alice">alice</options.Option>
+             {{#if this.showAlice}}
+               <options.Option @value="alice">alice</options.Option>
+             {{/if}}
              <options.Option @value="bob">bob</options.Option>
            </listbox.Options>
          </Listbox>
@@ -2772,15 +2780,24 @@ module('Integration | Component | <Listbox>', function (hooks) {
       await click(getListboxButton());
 
       let options = getListboxOptions();
+      assert.strictEqual(options.length, 2);
 
-      // Simulate a re-render race: the option's element leaves the DOM
-      // while the listbox still has it registered
-      options[0].remove();
+      this.set('showAlice', false);
+      await settled();
 
-      // Searching for the detached option must not throw
+      options = getListboxOptions();
+      assert.strictEqual(options.length, 1);
+      assert.strictEqual(options[0].getAttribute('data-index'), '0');
+
+      // Searching for the removed option must not select its stale value
       await typeWord('alice');
 
       assertListbox({ state: ListboxState.Visible });
+      assertNoActiveListboxOption();
+
+      await triggerKeyEvent(document.activeElement, 'keypress', 'Enter');
+
+      assert.verifySteps([]);
     });
 
     test('should be possible to search for a word (case insensitive)', async function () {


### PR DESCRIPTION
## Summary

This is a follow-up to #206.

PR #206 prevents `scrollIntoView` from throwing when typeahead finds an option element that has already been removed from the DOM. That fixes the immediate crash, but the removed option can still remain in the listbox's internal option registry.

In that stale-registry state, typeahead can treat a removed option as active, `aria-activedescendant` can point at an element that no longer exists, and pressing Enter can select the removed option's stale value.

This PR now fixes the issue at the registry layer:

- listbox options unregister themselves when their modifier is torn down
- remaining option elements/components are reindexed after removal
- active and selected option bookkeeping is recalculated after unregistering
- typeahead still skips disconnected option elements defensively

## What This Prevents

- removed options staying registered after a rerender
- typeahead activating an option that is no longer in the document
- `aria-activedescendant` referencing a removed element
- Enter selecting the stale value for a removed option

## Test Coverage

The detached-option regression test now removes an option through Ember rendering, then verifies:

- the removed option is unregistered
- the remaining option is reindexed to `data-index="0"`
- searching for the removed option leaves no active option
- pressing Enter does not call `onChange` with the removed option's value

## Verification

- `pnpm --filter test-app exec ember test --filter "unregister options that are no longer in the DOM"`
- `pnpm --filter test-app exec ember test --filter 'Listbox \`Any\` key aka search'`
- `pnpm --filter test-app exec ember test --filter "Integration | Component | <Listbox>"`
- `pnpm --filter test-app run lint:js`
- `git diff --check`

## Authorship

Authored by Codex.
