### PR TITLE
Fix importing-inject-from-ember-service deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,8 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          - ember-3-25
-          - ember-lts-3-28
-          - ember-4-0
-          - ember-4-4
+          - ember-lts-4.4
+          - ember-lts-4.8
           - ember-release
           - ember-beta
           - ember-canary

--- a/ember-headlessui/addon/components/dialog.ts
+++ b/ember-headlessui/addon/components/dialog.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { typeOf } from '@ember/utils';
 
 import { Keys } from 'ember-headlessui/utils/keyboard';

--- a/ember-headlessui/package.json
+++ b/ember-headlessui/package.json
@@ -46,7 +46,7 @@
     "tracked-maps-and-sets": "^3.0.1"
   },
   "peerDependencies": {
-    "ember-source": ">= 3.25.0 || ^4.0.0"
+    "ember-source": ">= 4.4.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -81,7 +81,7 @@
     "dotenv-cli": "^4.0.0",
     "ember-cli": "~4.4.0",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-source": "~3.25.0",
+    "ember-source": "~4.4.0",
     "ember-template-lint": "^3.5.1",
     "ember-template-lint-plugin-prettier": "^2.0.1",
     "eslint": "^7.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,8 @@ importers:
       '@glimmer/tracking': ^1.0.4
       '@nullvoxpopuli/eslint-configs': ^1.5.1
       '@types/ember': ^4.0.0
+      '@types/ember-qunit': ^5.0.0
+      '@types/ember-resolver': ^5.0.11
       '@types/ember__application': ^4.0.0
       '@types/ember__array': ^4.0.1
       '@types/ember__component': ^4.0.8
@@ -42,8 +44,6 @@ importers:
       '@types/ember__template': ^4.0.0
       '@types/ember__test': ^4.0.0
       '@types/ember__utils': ^4.0.0
-      '@types/ember-qunit': ^5.0.0
-      '@types/ember-resolver': ^5.0.11
       '@types/htmlbars-inline-precompile': ^3.0.0
       '@types/qunit': ^2.19.0
       '@types/rsvp': ^4.0.4
@@ -60,7 +60,7 @@ importers:
       ember-element-helper: ^0.6.0
       ember-modifier: ^4.0.0-beta.1
       ember-set-helper: ^2.0.1
-      ember-source: ~3.25.0
+      ember-source: ~4.4.0
       ember-template-lint: ^3.5.1
       ember-template-lint-plugin-prettier: ^2.0.1
       ember-truth-helpers: ^3.0.0
@@ -87,8 +87,8 @@ importers:
       ember-cli-htmlbars: 6.0.1
       ember-cli-typescript: 5.1.0
       ember-concurrency: 2.2.1
-      ember-element-helper: 0.6.1_ember-source@3.25.4
-      ember-modifier: 4.0.0-beta.1_ember-source@3.25.4
+      ember-element-helper: 0.6.1_ember-source@4.4.5
+      ember-modifier: 4.0.0-beta.1_ember-source@4.4.5
       ember-set-helper: 2.0.1
       ember-truth-helpers: 3.0.0
       focus-trap: 6.9.4
@@ -99,6 +99,8 @@ importers:
       '@glimmer/tracking': 1.1.2
       '@nullvoxpopuli/eslint-configs': 1.5.8_typescript@4.7.3
       '@types/ember': 4.0.0
+      '@types/ember-qunit': 5.0.0
+      '@types/ember-resolver': 5.0.11
       '@types/ember__application': 4.0.0
       '@types/ember__array': 4.0.1
       '@types/ember__component': 4.0.8
@@ -116,8 +118,6 @@ importers:
       '@types/ember__template': 4.0.0
       '@types/ember__test': 4.0.0
       '@types/ember__utils': 4.0.0
-      '@types/ember-qunit': 5.0.0
-      '@types/ember-resolver': 5.0.11
       '@types/htmlbars-inline-precompile': 3.0.0
       '@types/qunit': 2.19.0
       '@types/rsvp': 4.0.4
@@ -126,7 +126,7 @@ importers:
       dotenv-cli: 4.1.1
       ember-cli: 4.4.0
       ember-cli-inject-live-reload: 2.1.0
-      ember-source: 3.25.4
+      ember-source: 4.4.5_webpack@5.73.0
       ember-template-lint: 3.16.0
       ember-template-lint-plugin-prettier: 2.0.1_6wnbquydrbydwpj5rl2knu2tli
       eslint: 7.32.0
@@ -157,6 +157,8 @@ importers:
       '@testing-library/dom': ^8.1.0
       '@testing-library/user-event': ^13.1.9
       '@types/ember': ^4.0.0
+      '@types/ember-qunit': ^5.0.0
+      '@types/ember-resolver': ^5.0.11
       '@types/ember__application': ^4.0.0
       '@types/ember__array': ^4.0.1
       '@types/ember__component': ^4.0.8
@@ -174,8 +176,6 @@ importers:
       '@types/ember__test': ^4.0.0
       '@types/ember__test-helpers': ^2.6.1
       '@types/ember__utils': ^4.0.0
-      '@types/ember-qunit': ^5.0.0
-      '@types/ember-resolver': ^5.0.11
       '@types/htmlbars-inline-precompile': ^3.0.0
       '@types/qunit': ^2.19.0
       '@types/rsvp': ^4.0.4
@@ -205,7 +205,7 @@ importers:
       ember-page-title: ^7.0.0
       ember-qunit: ^5.1.5
       ember-resolver: ^8.0.3
-      ember-source: ~3.25.0
+      ember-source: ~4.4.0
       ember-source-channel-url: ^3.0.0
       ember-template-lint: ^3.5.1
       ember-template-lint-plugin-prettier: ^2.0.1
@@ -236,14 +236,14 @@ importers:
       ember-concurrency: 2.2.1
       ember-css-transitions: 4.1.0
       ember-headlessui: link:../ember-headlessui
-      ember-modifier: 4.0.0-beta.1_ember-source@3.25.4
+      ember-modifier: 4.0.0-beta.1_ember-source@4.4.5
       ember-page-title: 7.0.0
-      ember-source: 3.25.4
+      ember-source: 4.4.5_webpack@5.73.0
       ember-test-selectors: 6.0.0
-      tailwindcss: 3.1.2
+      tailwindcss: 3.1.2_postcss@8.4.14
     devDependencies:
       '@ember/optional-features': 2.0.0
-      '@ember/test-helpers': 2.8.1_ember-source@3.25.4
+      '@ember/test-helpers': 2.8.1_ember-source@4.4.5
       '@embroider/test-setup': 1.8.0
       '@glimmer/component': 1.1.2
       '@glimmer/tracking': 1.1.2
@@ -251,6 +251,8 @@ importers:
       '@testing-library/dom': 8.13.0
       '@testing-library/user-event': 13.5.0_tlwynutqiyp5mns3woioasuxnq
       '@types/ember': 4.0.0
+      '@types/ember-qunit': 5.0.0
+      '@types/ember-resolver': 5.0.11
       '@types/ember__application': 4.0.0
       '@types/ember__array': 4.0.1
       '@types/ember__component': 4.0.8
@@ -268,8 +270,6 @@ importers:
       '@types/ember__test': 4.0.0
       '@types/ember__test-helpers': 2.6.1
       '@types/ember__utils': 4.0.0
-      '@types/ember-qunit': 5.0.0
-      '@types/ember-resolver': 5.0.11
       '@types/htmlbars-inline-precompile': 3.0.0
       '@types/qunit': 2.19.0
       '@types/rsvp': 4.0.4
@@ -1428,17 +1428,6 @@ packages:
       '@babel/core': 7.18.2
       '@babel/helper-plugin-utils': 7.17.12
 
-  /@babel/plugin-transform-object-assign/7.16.7:
-    resolution: {integrity: sha512-R8mawvm3x0COTJtveuoqZIjNypn2FjfvXZr4pSQ8VhEFBuQGBz4XhHasZtHXjgXU4XptZ4HtGof3NoYc93ZH9Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-    dependencies:
-      '@babel/helper-plugin-utils': 7.17.12
-
   /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.18.2:
     resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
     engines: {node: '>=6.9.0'}
@@ -1866,7 +1855,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/test-helpers/2.8.1_ember-source@3.25.4:
+  /@ember/test-helpers/2.8.1_ember-source@4.4.5:
     resolution: {integrity: sha512-jbsYwWyAdhL/pdPu7Gb3SG1gvIXY70FWMtC/Us0Kmvk82Y+5YUQ1SOC0io75qmOGYQmH7eQrd/bquEVd+4XtdQ==}
     engines: {node: 10.* || 12.* || 14.* || 15.* || >= 16.*}
     peerDependencies:
@@ -1874,13 +1863,13 @@ packages:
     dependencies:
       '@ember/test-waiters': 3.0.2
       '@embroider/macros': 1.8.0
-      '@embroider/util': 1.8.0_ember-source@3.25.4
+      '@embroider/util': 1.8.0_ember-source@4.4.5
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-destroyable-polyfill: 2.0.3
-      ember-source: 3.25.4
+      ember-source: 4.4.5_webpack@5.73.0
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -1942,7 +1931,7 @@ packages:
       resolve: 1.22.0
     dev: true
 
-  /@embroider/util/1.8.0_ember-source@3.25.4:
+  /@embroider/util/1.8.0_ember-source@4.4.5:
     resolution: {integrity: sha512-uCR8fpBBVexW1FvqEJMzI52iiEM7aYJIIJgQ3S5za+d1Je2jPH3YUVJ2RR6gAxhjYBdazRG7FbUCYvZz/6cOPA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -1951,7 +1940,7 @@ packages:
       '@embroider/macros': 1.8.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 3.25.4
+      ember-source: 4.4.5_webpack@5.73.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2065,8 +2054,8 @@ packages:
       '@glimmer/global-context': 0.65.4
     dev: true
 
-  /@glimmer/vm-babel-plugins/0.77.5:
-    resolution: {integrity: sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==}
+  /@glimmer/vm-babel-plugins/0.83.1:
+    resolution: {integrity: sha512-Cz0e/SrOo1gSNA0PXZRYI1WGmlQSAQCpiERBlXjjpwoLgiqx2kvsjfFiCUC/CfpsO6WN6wuPMeTFGJuhSSeL5A==}
     dependencies:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
@@ -2328,7 +2317,7 @@ packages:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
-      tailwindcss: 3.1.2
+      tailwindcss: 3.1.2_postcss@8.4.14
     dev: false
 
   /@testing-library/dom/8.13.0:
@@ -2408,9 +2397,9 @@ packages:
   /@types/ember-qunit/5.0.0:
     resolution: {integrity: sha512-p7ZZUbohO5E57JsUC6fxD8gveV9LcSnPIx2J86WF7FNLno/2oKvWnI+j5AtobSoy86hfZZaYjiIuW0dNe1eblQ==}
     dependencies:
+      '@types/ember-resolver': 5.0.11
       '@types/ember__test': 4.0.0
       '@types/ember__test-helpers': 2.6.1
-      '@types/ember-resolver': 5.0.11
       '@types/qunit': 2.19.0
     dev: true
 
@@ -2447,10 +2436,10 @@ packages:
     resolution: {integrity: sha512-1Atwevfyu1/vjiezPPdP4s96BxWGelEQlCJRU5ZQV9WlzVuMTuCDPumZ1lQdS4/EYycFZeod030FjE3CT9mZFA==}
     dependencies:
       '@types/ember': 4.0.0
+      '@types/ember-resolver': 5.0.11
       '@types/ember__engine': 4.0.0
       '@types/ember__object': 4.0.2
       '@types/ember__routing': 4.0.7
-      '@types/ember-resolver': 5.0.11
     dev: true
 
   /@types/ember__array/4.0.1:
@@ -2476,8 +2465,8 @@ packages:
   /@types/ember__debug/4.0.1:
     resolution: {integrity: sha512-qrKk6Ujh6oev7TSB0eB7AEmQWKCt5t84k/K3hDvJXUiLU3YueN0kyt7aPoIAkVjC111A9FqDugl9n60+N5yeEw==}
     dependencies:
-      '@types/ember__object': 4.0.2
       '@types/ember-resolver': 5.0.11
+      '@types/ember__object': 4.0.2
     dev: true
 
   /@types/ember__destroyable/4.0.0:
@@ -2487,8 +2476,8 @@ packages:
   /@types/ember__engine/4.0.0:
     resolution: {integrity: sha512-AfJHIWaBeZ+TZWJbSoUz7LK+z8uNPjMqmucz8C5u+EV2NDiaq02oGPTB4SeKInLNBMga8c5xvz0gVefZJnTBnQ==}
     dependencies:
-      '@types/ember__object': 4.0.2
       '@types/ember-resolver': 5.0.11
+      '@types/ember__object': 4.0.2
     dev: true
 
   /@types/ember__error/4.0.0:
@@ -2538,9 +2527,9 @@ packages:
   /@types/ember__test-helpers/2.6.1:
     resolution: {integrity: sha512-d2RShuBSaBzp04nt8ad+mNE1F6rbIcIIud8WFUVQqGSUGHuZQUq1051Jza12ksCUnXduyE/J9UDjyZvNKOHeBQ==}
     dependencies:
+      '@types/ember-resolver': 5.0.11
       '@types/ember__application': 4.0.0
       '@types/ember__error': 4.0.0
-      '@types/ember-resolver': 5.0.11
       '@types/htmlbars-inline-precompile': 3.0.0
     dev: true
 
@@ -3143,7 +3132,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.11.0
-    dev: false
 
   /ajv-keywords/3.5.2_ajv@6.12.6:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -3159,7 +3147,6 @@ packages:
     dependencies:
       ajv: 8.11.0
       fast-deep-equal: 3.1.3
-    dev: false
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3618,7 +3605,6 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.73.0
-    dev: false
 
   /babel-loader/8.2.5_lzsemofhph6vepnub4bnemnm6m:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
@@ -4191,7 +4177,6 @@ packages:
     dependencies:
       broccoli-plugin: 1.3.1
       mkdirp: 0.5.6
-    dev: true
 
   /broccoli-filter/1.3.0:
     resolution: {integrity: sha512-VXJXw7eBfG82CFxaBDjYmyN7V72D4In2zwLVQJd/h3mBfF3CMdRTsv2L20lmRTtCv1sAHcB+LgMso90e/KYiLw==}
@@ -5591,7 +5576,6 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.7
       webpack: 5.73.0
-    dev: false
 
   /css-tree/1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
@@ -5613,7 +5597,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /cyclist/1.0.1:
     resolution: {integrity: sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==}
@@ -6016,7 +5999,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - webpack
-    dev: false
 
   /ember-cli-app-version/5.0.0:
     resolution: {integrity: sha512-afhx/CXDOMNXzoe4NDPy5WUfxWmYYHUzMCiTyvPBxCDBXYcMrtxNWxvgaSaeqcoHVEmqzeyBj8V82tzmT1dcyw==}
@@ -6224,6 +6206,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /ember-cli-typescript-blueprint-polyfill/0.1.0:
+    resolution: {integrity: sha512-g0weUTOnHmPGqVZzkQTl3Nbk9fzEdFkEXydCs5mT1qBjXh8eQ6VlmjjGD5/998UXKuA0pLSCVVMbSp/linLzGA==}
+    dependencies:
+      chalk: 4.1.2
+      remove-types: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /ember-cli-typescript/2.0.2:
     resolution: {integrity: sha512-7I5azCTxOgRDN8aSSnJZIKSqr+MGnT+jLTUbBYqF8wu6ojs2DUnTePxUcQMcvNh3Q3B1ySv7Q/uZFSjdU9gSjA==}
@@ -6565,16 +6555,16 @@ packages:
       - '@babel/core'
       - supports-color
 
-  /ember-element-helper/0.6.1_ember-source@3.25.4:
+  /ember-element-helper/0.6.1_ember-source@4.4.5:
     resolution: {integrity: sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
       ember-source: ^3.8 || 4
     dependencies:
-      '@embroider/util': 1.8.0_ember-source@3.25.4
+      '@embroider/util': 1.8.0_ember-source@4.4.5
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.0.1
-      ember-source: 3.25.4
+      ember-source: 4.4.5_webpack@5.73.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6646,7 +6636,7 @@ packages:
       - supports-color
     dev: false
 
-  /ember-modifier/4.0.0-beta.1_ember-source@3.25.4:
+  /ember-modifier/4.0.0-beta.1_ember-source@4.4.5:
     resolution: {integrity: sha512-Mg4NRDCbydlF9hXUzmR9B89GcImA/oDFSK3nFNmy/nQLn5B30zDx8OlL132g9vnnbH/DavlxXwsuv3rDs9g13A==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
@@ -6658,7 +6648,7 @@ packages:
       '@embroider/addon-shim': 1.8.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 3.25.4
+      ember-source: 4.4.5_webpack@5.73.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6688,7 +6678,7 @@ packages:
       '@ember/test-helpers': ^2.4.0
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.8.1_ember-source@3.25.4
+      '@ember/test-helpers': 2.8.1_ember-source@4.4.5
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
@@ -6752,38 +6742,40 @@ packages:
       - encoding
     dev: true
 
-  /ember-source/3.25.4:
-    resolution: {integrity: sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==}
-    engines: {node: 10.* || >= 12.*}
+  /ember-source/4.4.5_webpack@5.73.0:
+    resolution: {integrity: sha512-5U+IYHEb2XPokrLEQBy6N2+MwbE909K4RKKQxOLQEwnThWcO2cTTLTbz7z3biYL4vyne04ygXVqzlfUtKWwVQQ==}
+    engines: {node: '>= 12.*'}
     dependencies:
       '@babel/helper-module-imports': 7.16.7
       '@babel/plugin-transform-block-scoping': 7.18.4
-      '@babel/plugin-transform-object-assign': 7.16.7
       '@ember/edition-utils': 1.2.0
-      '@glimmer/vm-babel-plugins': 0.77.5
+      '@glimmer/vm-babel-plugins': 0.83.1
       babel-plugin-debug-macros: 0.3.4
       babel-plugin-filter-imports: 4.0.0
       broccoli-concat: 4.2.5
       broccoli-debug: 0.6.5
-      broccoli-funnel: 2.0.2
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
+      ember-auto-import: 2.4.2_webpack@5.73.0
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
       ember-cli-version-checker: 5.1.2
       ember-router-generator: 2.0.0
       inflection: 1.13.2
-      jquery: 3.6.0
       resolve: 1.22.0
-      semver: 6.3.0
+      semver: 7.3.7
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+      - webpack
 
   /ember-template-lint-plugin-prettier/2.0.1_6wnbquydrbydwpj5rl2knu2tli:
     resolution: {integrity: sha512-MPlyq1lNlL7U7EamXbmpjIUjHVQUARwmR+TJEmWZcf8lq/ExnV6Jyk3uvmrEXKOfsQS6egpoNgs3wqfh8qAP6Q==}
@@ -8093,7 +8085,6 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
 
   /fs-extra/4.0.3:
     resolution: {integrity: sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==}
@@ -8211,7 +8202,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -8826,7 +8817,6 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.14
-    dev: false
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -9453,9 +9443,6 @@ packages:
       '@types/node': 17.0.42
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  /jquery/3.6.0:
-    resolution: {integrity: sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==}
 
   /js-string-escape/1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
@@ -10250,7 +10237,6 @@ packages:
     dependencies:
       schema-utils: 4.0.0
       webpack: 5.73.0
-    dev: false
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -11284,7 +11270,6 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.14
-    dev: false
 
   /postcss-modules-local-by-default/4.0.0_postcss@8.4.14:
     resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
@@ -11296,7 +11281,6 @@ packages:
       postcss: 8.4.14
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-modules-scope/3.0.0_postcss@8.4.14:
     resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
@@ -11306,7 +11290,6 @@ packages:
     dependencies:
       postcss: 8.4.14
       postcss-selector-parser: 6.0.10
-    dev: false
 
   /postcss-modules-values/4.0.0_postcss@8.4.14:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
@@ -11316,7 +11299,6 @@ packages:
     dependencies:
       icss-utils: 5.1.0_postcss@8.4.14
       postcss: 8.4.14
-    dev: false
 
   /postcss-nested/5.0.6_postcss@8.4.14:
     resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
@@ -11334,7 +11316,6 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: false
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -11379,7 +11360,6 @@ packages:
     resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
 
   /pretty-format/27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -11958,7 +11938,6 @@ packages:
       prettier: 2.6.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /repeat-element/1.1.4:
     resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
@@ -12294,7 +12273,6 @@ packages:
       ajv: 8.11.0
       ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
-    dev: false
 
   /semver-diff/3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
@@ -12952,7 +12930,6 @@ packages:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
       webpack: 5.73.0
-    dev: false
 
   /styled_string/0.0.1:
     resolution: {integrity: sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko=}
@@ -13032,10 +13009,12 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.1.2:
+  /tailwindcss/3.1.2_postcss@8.4.14:
     resolution: {integrity: sha512-yJ6L5s1U5AeS5g7HHy212zdQfjwD426FBfm59pet/JsyneuZuD4C2W7PpJEg4ppisiB21uLqtNagv8KXury3+Q==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -13878,7 +13857,6 @@ packages:
       ensure-posix-path: 1.1.1
       matcher-collection: 2.0.1
       minimatch: 3.1.2
-    dev: false
 
   /walker/1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -8,34 +8,18 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-3-25',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.25.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3-28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
-        name: 'ember-4-0',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.0.0',
-          },
-        },
-      },
-      {
-        name: 'ember-4-4',
+        name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
           },
         },
       },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -31,7 +31,7 @@
     "ember-headlessui": "*",
     "ember-modifier": "4.0.0-beta.1",
     "ember-page-title": "^7.0.0",
-    "ember-source": "~3.25.0",
+    "ember-source": "~4.4.0",
     "ember-test-selectors": "^6.0.0",
     "tailwindcss": "^3.0.24"
   },


### PR DESCRIPTION
Closes https://github.com/GavinJoyce/ember-headlessui/issues/208

There was only one occurrence of `inject as service` in the repo. 

From what I see [on the deprecation page](https://deprecations.emberjs.com/id/importing-inject-from-ember-service/), the `service` API is available from Ember v4.1. That raises the floor for the addon, which was currently tested against even v3.25. I moved it up to v4.4 because that was an LTS at the time.  This makes it a breaking change.